### PR TITLE
Fix paths for executables

### DIFF
--- a/mrpast/helpers.py
+++ b/mrpast/helpers.py
@@ -45,7 +45,8 @@ def which(exe: str, required=False) -> Optional[str]:
     except subprocess.CalledProcessError:
         result = None
     if result is None:
-        for p in sys.path + [os.path.realpath(os.path.dirname(__file__))]:
+        sys_paths = [os.path.join(p, "mrpast") for p in sys.path]
+        for p in sys_paths + [os.path.realpath(os.path.dirname(__file__))]:
             p = os.path.join(p, exe)
             if os.path.isfile(p):
                 result = p

--- a/setup.py
+++ b/setup.py
@@ -111,7 +111,7 @@ setup(
         "Operating System :: POSIX :: Linux",
     ],
     package_data={
-        PACKAGE_NAME: [SOLVER_NAME],
+        PACKAGE_NAME: [SOLVER_NAME, EVAL_NAME],
     },
     include_package_data=True,
     entry_points={


### PR DESCRIPTION
* mrp-eval wasn't being added to the package data
* the Python system paths weren't being search properly