### PR TITLE
Work-around for NLopt solver getting stuck

### DIFF
--- a/src/objective.h
+++ b/src/objective.h
@@ -313,10 +313,12 @@ public:
     void resetSolveStats() {
         m_numObjCalls = 1;
         m_minValue = std::numeric_limits<double>::max();
+        m_callsAtMinValue = 0;
     }
 
     size_t m_numObjCalls;
     double m_minValue;
+    size_t m_callsAtMinValue;
 
 private:
     const bool m_maximization;


### PR DESCRIPTION
This happens very rarely, and appears to be related to numerical issues (e.g., time slices that have no coalescences in them, etc), but it is annoying when it does:
the solver never improves on the minimum objective function values, and I suspect it is just ping-ponging between values internally.

Now we kill the solver if it runs for 2,000 iterations without improving upon the minimum value.