### PR TITLE
Better model YAML, support for fixed parameters

### DIFF
--- a/examples/20deme1epoch.yaml
+++ b/examples/20deme1epoch.yaml
@@ -1,358 +1,174 @@
 ploidy: 2
+pop_count: 20
 coalescence:
-  vectors:
-  - [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20]
+  entries:
+  - {"epoch": 0, "deme": 0, "rate": {"param": 1}}
+  - {"epoch": 0, "deme": 1, "rate": {"param": 2}}
+  - {"epoch": 0, "deme": 2, "rate": {"param": 3}}
+  - {"epoch": 0, "deme": 3, "rate": {"param": 4}}
+  - {"epoch": 0, "deme": 4, "rate": {"param": 5}}
+  - {"epoch": 0, "deme": 5, "rate": {"param": 6}}
+  - {"epoch": 0, "deme": 6, "rate": {"param": 7}}
+  - {"epoch": 0, "deme": 7, "rate": {"param": 8}}
+  - {"epoch": 0, "deme": 8, "rate": {"param": 9}}
+  - {"epoch": 0, "deme": 9, "rate": {"param": 10}}
+  - {"epoch": 0, "deme": 10, "rate": {"param": 11}}
+  - {"epoch": 0, "deme": 11, "rate": {"param": 12}}
+  - {"epoch": 0, "deme": 12, "rate": {"param": 13}}
+  - {"epoch": 0, "deme": 13, "rate": {"param": 14}}
+  - {"epoch": 0, "deme": 14, "rate": {"param": 15}}
+  - {"epoch": 0, "deme": 15, "rate": {"param": 16}}
+  - {"epoch": 0, "deme": 16, "rate": {"param": 17}}
+  - {"epoch": 0, "deme": 17, "rate": {"param": 18}}
+  - {"epoch": 0, "deme": 18, "rate": {"param": 19}}
+  - {"epoch": 0, "deme": 19, "rate": {"param": 20}}
   parameters:
-  - ground_truth: 5.077924e-04
-    lb: 1.0e-05
-    ub: 0.01
-    index: 1
-  - ground_truth: 8.364338e-04
-    lb: 1.0e-05
-    ub: 0.01
-    index: 2
-  - ground_truth: 8.779979e-05
-    lb: 1.0e-05
-    ub: 0.01
-    index: 3
-  - ground_truth: 5.430444e-05
-    lb: 1.0e-05
-    ub: 0.01
-    index: 4
-  - ground_truth: 5.430444e-04
-    lb: 1.0e-05
-    ub: 0.01
-    index: 5
-  - ground_truth: 0.00016078033758503007
-    lb: 1.0e-5
-    ub: 0.01
-    index: 6
-  - ground_truth: 0.001116338901687122
-    lb: 1.0e-5
-    ub: 0.01
-    index: 7
-  - ground_truth: 6.294280435313211e-05
-    lb: 1.0e-5
-    ub: 0.01
-    index: 8
-  - ground_truth: 0.00020430538939645044
-    lb: 1.0e-5
-    ub: 0.01
-    index: 9
-  - ground_truth: 0.0002522382918480849
-    lb: 1.0e-5
-    ub: 0.01
-    index: 10
-  - ground_truth: 0.0002508036356997956
-    lb: 1.0e-5
-    ub: 0.01
-    index: 11
-  - ground_truth: 5.737870990328752e-05
-    lb: 1.0e-5
-    ub: 0.01
-    index: 12
-  - ground_truth: 6.205184304511677e-05
-    lb: 1.0e-5
-    ub: 0.01
-    index: 13
-  - ground_truth: 0.00017090789839437108
-    lb: 1.0e-5
-    ub: 0.01
-    index: 14
-  - ground_truth: 6.584009612640476e-05
-    lb: 1.0e-5
-    ub: 0.01
-    index: 15
-  - ground_truth: 0.0015043757166814165
-    lb: 1.0e-5
-    ub: 0.01
-    index: 16
-  - ground_truth: 8.468295456303138e-05
-    lb: 1.0e-5
-    ub: 0.01
-    index: 17
-  - ground_truth: 0.0011434649343112682
-    lb: 1.0e-5
-    ub: 0.01
-    index: 18
-  - ground_truth: 0.00024700085864890105
-    lb: 1.0e-5
-    ub: 0.01
-    index: 19
-  - ground_truth: 0.0001225209937206409
-    lb: 1.0e-5
-    ub: 0.01
-    index: 20
-epochTimeSplit: null
-populationConversion: null
+  - {"ground_truth": 0.0005077924, "lb": 1e-05, "ub": 0.01, "index": 1}
+  - {"ground_truth": 0.0008364338, "lb": 1e-05, "ub": 0.01, "index": 2}
+  - {"ground_truth": 8.779979e-05, "lb": 1e-05, "ub": 0.01, "index": 3}
+  - {"ground_truth": 5.430444e-05, "lb": 1e-05, "ub": 0.01, "index": 4}
+  - {"ground_truth": 0.0005430444, "lb": 1e-05, "ub": 0.01, "index": 5}
+  - {"ground_truth": 0.00016078033758503007, "lb": 1e-05, "ub": 0.01, "index": 6}
+  - {"ground_truth": 0.001116338901687122, "lb": 1e-05, "ub": 0.01, "index": 7}
+  - {"ground_truth": 6.294280435313211e-05, "lb": 1e-05, "ub": 0.01, "index": 8}
+  - {"ground_truth": 0.00020430538939645044, "lb": 1e-05, "ub": 0.01, "index": 9}
+  - {"ground_truth": 0.0002522382918480849, "lb": 1e-05, "ub": 0.01, "index": 10}
+  - {"ground_truth": 0.0002508036356997956, "lb": 1e-05, "ub": 0.01, "index": 11}
+  - {"ground_truth": 5.737870990328752e-05, "lb": 1e-05, "ub": 0.01, "index": 12}
+  - {"ground_truth": 6.205184304511677e-05, "lb": 1e-05, "ub": 0.01, "index": 13}
+  - {"ground_truth": 0.00017090789839437108, "lb": 1e-05, "ub": 0.01, "index": 14}
+  - {"ground_truth": 6.584009612640476e-05, "lb": 1e-05, "ub": 0.01, "index": 15}
+  - {"ground_truth": 0.0015043757166814165, "lb": 1e-05, "ub": 0.01, "index": 16}
+  - {"ground_truth": 8.468295456303138e-05, "lb": 1e-05, "ub": 0.01, "index": 17}
+  - {"ground_truth": 0.0011434649343112682, "lb": 1e-05, "ub": 0.01, "index": 18}
+  - {"ground_truth": 0.00024700085864890105, "lb": 1e-05, "ub": 0.01, "index": 19}
+  - {"ground_truth": 0.0001225209937206409, "lb": 1e-05, "ub": 0.01, "index": 20}
 migration:
-  matrices:
-  - [ [0, 2, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-      [5, 0, 4, 0, 0, 0, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-      [0, 8, 0, 7, 0, 0, 0, 6, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-      [0, 0, 11, 0, 10, 0, 0, 0, 9, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-      [0, 0, 0, 13, 0, 0, 0, 0, 0, 12, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-      [14, 0, 0, 0, 0, 0, 16, 0, 0, 0, 15, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-      [0, 17, 0, 0, 0, 20, 0, 19, 0, 0, 0, 18, 0, 0, 0, 0, 0, 0, 0, 0],
-      [0, 0, 21, 0, 0, 0, 24, 0, 23, 0, 0, 0, 22, 0, 0, 0, 0, 0, 0, 0],
-      [0, 0, 0, 25, 0, 0, 0, 28, 0, 27, 0, 0, 0, 26, 0, 0, 0, 0, 0, 0],
-      [0, 0, 0, 0, 29, 0, 0, 0, 31, 0, 0, 0, 0, 0, 30, 0, 0, 0, 0, 0],
-      [0, 0, 0, 0, 0, 32, 0, 0, 0, 0, 0, 34, 0, 0, 0, 33, 0, 0, 0, 0],
-      [0, 0, 0, 0, 0, 0, 35, 0, 0, 0, 38, 0, 37, 0, 0, 0, 36, 0, 0, 0],
-      [0, 0, 0, 0, 0, 0, 0, 39, 0, 0, 0, 42, 0, 41, 0, 0, 0, 40, 0, 0],
-      [0, 0, 0, 0, 0, 0, 0, 0, 43, 0, 0, 0, 46, 0, 45, 0, 0, 0, 44, 0],
-      [0, 0, 0, 0, 0, 0, 0, 0, 0, 47, 0, 0, 0, 49, 0, 0, 0, 0, 0, 48],
-      [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 50, 0, 0, 0, 0, 0, 51, 0, 0, 0],
-      [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 52, 0, 0, 0, 54, 0, 53, 0, 0],
-      [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 55, 0, 0, 0, 57, 0, 56, 0],
-      [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 58, 0, 0, 0, 60, 0, 59],
-      [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 61, 0, 0, 0, 62, 0] ]
+  entries:
+  - {"epoch": 0, "source": 0, "dest": 1, "rate": {"param": 2}}
+  - {"epoch": 0, "source": 0, "dest": 5, "rate": {"param": 1}}
+  - {"epoch": 0, "source": 1, "dest": 0, "rate": {"param": 5}}
+  - {"epoch": 0, "source": 1, "dest": 2, "rate": {"param": 4}}
+  - {"epoch": 0, "source": 1, "dest": 6, "rate": {"param": 3}}
+  - {"epoch": 0, "source": 2, "dest": 1, "rate": {"param": 8}}
+  - {"epoch": 0, "source": 2, "dest": 3, "rate": {"param": 7}}
+  - {"epoch": 0, "source": 2, "dest": 7, "rate": {"param": 6}}
+  - {"epoch": 0, "source": 3, "dest": 2, "rate": {"param": 11}}
+  - {"epoch": 0, "source": 3, "dest": 4, "rate": {"param": 10}}
+  - {"epoch": 0, "source": 3, "dest": 8, "rate": {"param": 9}}
+  - {"epoch": 0, "source": 4, "dest": 3, "rate": {"param": 13}}
+  - {"epoch": 0, "source": 4, "dest": 9, "rate": {"param": 12}}
+  - {"epoch": 0, "source": 5, "dest": 0, "rate": {"param": 14}}
+  - {"epoch": 0, "source": 5, "dest": 6, "rate": {"param": 16}}
+  - {"epoch": 0, "source": 5, "dest": 10, "rate": {"param": 15}}
+  - {"epoch": 0, "source": 6, "dest": 1, "rate": {"param": 17}}
+  - {"epoch": 0, "source": 6, "dest": 5, "rate": {"param": 20}}
+  - {"epoch": 0, "source": 6, "dest": 7, "rate": {"param": 19}}
+  - {"epoch": 0, "source": 6, "dest": 11, "rate": {"param": 18}}
+  - {"epoch": 0, "source": 7, "dest": 2, "rate": {"param": 21}}
+  - {"epoch": 0, "source": 7, "dest": 6, "rate": {"param": 24}}
+  - {"epoch": 0, "source": 7, "dest": 8, "rate": {"param": 23}}
+  - {"epoch": 0, "source": 7, "dest": 12, "rate": {"param": 22}}
+  - {"epoch": 0, "source": 8, "dest": 3, "rate": {"param": 25}}
+  - {"epoch": 0, "source": 8, "dest": 7, "rate": {"param": 28}}
+  - {"epoch": 0, "source": 8, "dest": 9, "rate": {"param": 27}}
+  - {"epoch": 0, "source": 8, "dest": 13, "rate": {"param": 26}}
+  - {"epoch": 0, "source": 9, "dest": 4, "rate": {"param": 29}}
+  - {"epoch": 0, "source": 9, "dest": 8, "rate": {"param": 31}}
+  - {"epoch": 0, "source": 9, "dest": 14, "rate": {"param": 30}}
+  - {"epoch": 0, "source": 10, "dest": 5, "rate": {"param": 32}}
+  - {"epoch": 0, "source": 10, "dest": 11, "rate": {"param": 34}}
+  - {"epoch": 0, "source": 10, "dest": 15, "rate": {"param": 33}}
+  - {"epoch": 0, "source": 11, "dest": 6, "rate": {"param": 35}}
+  - {"epoch": 0, "source": 11, "dest": 10, "rate": {"param": 38}}
+  - {"epoch": 0, "source": 11, "dest": 12, "rate": {"param": 37}}
+  - {"epoch": 0, "source": 11, "dest": 16, "rate": {"param": 36}}
+  - {"epoch": 0, "source": 12, "dest": 7, "rate": {"param": 39}}
+  - {"epoch": 0, "source": 12, "dest": 11, "rate": {"param": 42}}
+  - {"epoch": 0, "source": 12, "dest": 13, "rate": {"param": 41}}
+  - {"epoch": 0, "source": 12, "dest": 17, "rate": {"param": 40}}
+  - {"epoch": 0, "source": 13, "dest": 8, "rate": {"param": 43}}
+  - {"epoch": 0, "source": 13, "dest": 12, "rate": {"param": 46}}
+  - {"epoch": 0, "source": 13, "dest": 14, "rate": {"param": 45}}
+  - {"epoch": 0, "source": 13, "dest": 18, "rate": {"param": 44}}
+  - {"epoch": 0, "source": 14, "dest": 9, "rate": {"param": 47}}
+  - {"epoch": 0, "source": 14, "dest": 13, "rate": {"param": 49}}
+  - {"epoch": 0, "source": 14, "dest": 19, "rate": {"param": 48}}
+  - {"epoch": 0, "source": 15, "dest": 10, "rate": {"param": 50}}
+  - {"epoch": 0, "source": 15, "dest": 16, "rate": {"param": 51}}
+  - {"epoch": 0, "source": 16, "dest": 11, "rate": {"param": 52}}
+  - {"epoch": 0, "source": 16, "dest": 15, "rate": {"param": 54}}
+  - {"epoch": 0, "source": 16, "dest": 17, "rate": {"param": 53}}
+  - {"epoch": 0, "source": 17, "dest": 12, "rate": {"param": 55}}
+  - {"epoch": 0, "source": 17, "dest": 16, "rate": {"param": 57}}
+  - {"epoch": 0, "source": 17, "dest": 18, "rate": {"param": 56}}
+  - {"epoch": 0, "source": 18, "dest": 13, "rate": {"param": 58}}
+  - {"epoch": 0, "source": 18, "dest": 17, "rate": {"param": 60}}
+  - {"epoch": 0, "source": 18, "dest": 19, "rate": {"param": 59}}
+  - {"epoch": 0, "source": 19, "dest": 14, "rate": {"param": 61}}
+  - {"epoch": 0, "source": 19, "dest": 18, "rate": {"param": 62}}
   parameters:
-  - ground_truth: 5.171935932074151e-05
-    lb: 1.0e-5
-    ub: 0.01
-    index: 1
-  - ground_truth: 0.007841245548941916
-    lb: 1.0e-5
-    ub: 0.01
-    index: 2
-  - ground_truth: 0.0006410389337787374
-    lb: 1.0e-5
-    ub: 0.01
-    index: 3
-  - ground_truth: 8.71593110900636e-05
-    lb: 1.0e-5
-    ub: 0.01
-    index: 4
-  - ground_truth: 0.0004977288008368388
-    lb: 1.0e-5
-    ub: 0.01
-    index: 5
-  - ground_truth: 0.0009414987762790531
-    lb: 1.0e-5
-    ub: 0.01
-    index: 6
-  - ground_truth: 0.004280248482251689
-    lb: 1.0e-5
-    ub: 0.01
-    index: 7
-  - ground_truth: 6.535494391138009e-05
-    lb: 1.0e-5
-    ub: 0.01
-    index: 8
-  - ground_truth: 1.5420114876502724e-05
-    lb: 1.0e-5
-    ub: 0.01
-    index: 9
-  - ground_truth: 0.000425028183994456
-    lb: 1.0e-5
-    ub: 0.01
-    index: 10
-  - ground_truth: 0.006992201689203382
-    lb: 1.0e-5
-    ub: 0.01
-    index: 11
-  - ground_truth: 7.706062793082981e-05
-    lb: 1.0e-5
-    ub: 0.01
-    index: 12
-  - ground_truth: 0.008691324429020193
-    lb: 1.0e-5
-    ub: 0.01
-    index: 13
-  - ground_truth: 0.0014445830094055269
-    lb: 1.0e-5
-    ub: 0.01
-    index: 14
-  - ground_truth: 0.0001244441628555007
-    lb: 1.0e-5
-    ub: 0.01
-    index: 15
-  - ground_truth: 0.007453296965432761
-    lb: 1.0e-5
-    ub: 0.01
-    index: 16
-  - ground_truth: 0.008799113445489297
-    lb: 1.0e-5
-    ub: 0.01
-    index: 17
-  - ground_truth: 0.0003934024741723284
-    lb: 1.0e-5
-    ub: 0.01
-    index: 18
-  - ground_truth: 5.620547124633913e-05
-    lb: 1.0e-5
-    ub: 0.01
-    index: 19
-  - ground_truth: 0.002449720226286379
-    lb: 1.0e-5
-    ub: 0.01
-    index: 20
-  - ground_truth: 4.556566498892201e-05
-    lb: 1.0e-5
-    ub: 0.01
-    index: 21
-  - ground_truth: 1.0291366001813238e-05
-    lb: 1.0e-5
-    ub: 0.01
-    index: 22
-  - ground_truth: 5.942718356120848e-05
-    lb: 1.0e-5
-    ub: 0.01
-    index: 23
-  - ground_truth: 7.895433941807506e-05
-    lb: 1.0e-5
-    ub: 0.01
-    index: 24
-  - ground_truth: 2.4655036978916396e-05
-    lb: 1.0e-5
-    ub: 0.01
-    index: 25
-  - ground_truth: 5.641244988008681e-05
-    lb: 1.0e-5
-    ub: 0.01
-    index: 26
-  - ground_truth: 0.0005496186797839989
-    lb: 1.0e-5
-    ub: 0.01
-    index: 27
-  - ground_truth: 0.0002442364215847237
-    lb: 1.0e-5
-    ub: 0.01
-    index: 28
-  - ground_truth: 9.039964909436815e-05
-    lb: 1.0e-5
-    ub: 0.01
-    index: 29
-  - ground_truth: 0.0003099379267392234
-    lb: 1.0e-5
-    ub: 0.01
-    index: 30
-  - ground_truth: 3.5044324392258984e-05
-    lb: 1.0e-5
-    ub: 0.01
-    index: 31
-  - ground_truth: 8.68977823704281e-05
-    lb: 1.0e-5
-    ub: 0.01
-    index: 32
-  - ground_truth: 6.598111996737249e-05
-    lb: 1.0e-5
-    ub: 0.01
-    index: 33
-  - ground_truth: 0.0001268317077344063
-    lb: 1.0e-5
-    ub: 0.01
-    index: 34
-  - ground_truth: 0.0017958472097867402
-    lb: 1.0e-5
-    ub: 0.01
-    index: 35
-  - ground_truth: 0.00511094010497419
-    lb: 1.0e-5
-    ub: 0.01
-    index: 36
-  - ground_truth: 0.0007086552427081451
-    lb: 1.0e-5
-    ub: 0.01
-    index: 37
-  - ground_truth: 0.0005339865898496273
-    lb: 1.0e-5
-    ub: 0.01
-    index: 38
-  - ground_truth: 0.000875914857887453
-    lb: 1.0e-5
-    ub: 0.01
-    index: 39
-  - ground_truth: 0.0001849463656004242
-    lb: 1.0e-5
-    ub: 0.01
-    index: 40
-  - ground_truth: 3.829076775526719e-05
-    lb: 1.0e-5
-    ub: 0.01
-    index: 41
-  - ground_truth: 0.0015708319631987423
-    lb: 1.0e-5
-    ub: 0.01
-    index: 42
-  - ground_truth: 0.0003889260284959057
-    lb: 1.0e-5
-    ub: 0.01
-    index: 43
-  - ground_truth: 8.306624072392709e-05
-    lb: 1.0e-5
-    ub: 0.01
-    index: 44
-  - ground_truth: 2.478789923615565e-05
-    lb: 1.0e-5
-    ub: 0.01
-    index: 45
-  - ground_truth: 0.00029760232157877435
-    lb: 1.0e-5
-    ub: 0.01
-    index: 46
-  - ground_truth: 2.7152865488279057e-05
-    lb: 1.0e-5
-    ub: 0.01
-    index: 47
-  - ground_truth: 7.649770462411239e-05
-    lb: 1.0e-5
-    ub: 0.01
-    index: 48
-  - ground_truth: 0.006509845911451317
-    lb: 1.0e-5
-    ub: 0.01
-    index: 49
-  - ground_truth: 7.658828630610365e-05
-    lb: 1.0e-5
-    ub: 0.01
-    index: 50
-  - ground_truth: 0.0011452041358598355
-    lb: 1.0e-5
-    ub: 0.01
-    index: 51
-  - ground_truth: 0.0008615563010281715
-    lb: 1.0e-5
-    ub: 0.01
-    index: 52
-  - ground_truth: 0.00937120216704011
-    lb: 1.0e-5
-    ub: 0.01
-    index: 53
-  - ground_truth: 8.688159947187885e-05
-    lb: 1.0e-5
-    ub: 0.01
-    index: 54
-  - ground_truth: 0.0003343984343148916
-    lb: 1.0e-5
-    ub: 0.01
-    index: 55
-  - ground_truth: 0.0005770302974943314
-    lb: 1.0e-5
-    ub: 0.01
-    index: 56
-  - ground_truth: 6.342877075796101e-05
-    lb: 1.0e-5
-    ub: 0.01
-    index: 57
-  - ground_truth: 0.0005221159409091538
-    lb: 1.0e-5
-    ub: 0.01
-    index: 58
-  - ground_truth: 0.00034622379768388265
-    lb: 1.0e-5
-    ub: 0.01
-    index: 59
-  - ground_truth: 0.0097543307299165
-    lb: 1.0e-5
-    ub: 0.01
-    index: 60
-  - ground_truth: 6.166215877718817e-05
-    lb: 1.0e-5
-    ub: 0.01
-    index: 61
-  - ground_truth: 0.0004646258648173351
-    lb: 1.0e-5
-    ub: 0.01
-    index: 62
+  - {"ground_truth": 5.171935932074151e-05, "lb": 1e-05, "ub": 0.01, "index": 1}
+  - {"ground_truth": 0.007841245548941916, "lb": 1e-05, "ub": 0.01, "index": 2}
+  - {"ground_truth": 0.0006410389337787374, "lb": 1e-05, "ub": 0.01, "index": 3}
+  - {"ground_truth": 8.71593110900636e-05, "lb": 1e-05, "ub": 0.01, "index": 4}
+  - {"ground_truth": 0.0004977288008368388, "lb": 1e-05, "ub": 0.01, "index": 5}
+  - {"ground_truth": 0.0009414987762790531, "lb": 1e-05, "ub": 0.01, "index": 6}
+  - {"ground_truth": 0.004280248482251689, "lb": 1e-05, "ub": 0.01, "index": 7}
+  - {"ground_truth": 6.535494391138009e-05, "lb": 1e-05, "ub": 0.01, "index": 8}
+  - {"ground_truth": 1.5420114876502724e-05, "lb": 1e-05, "ub": 0.01, "index": 9}
+  - {"ground_truth": 0.000425028183994456, "lb": 1e-05, "ub": 0.01, "index": 10}
+  - {"ground_truth": 0.006992201689203382, "lb": 1e-05, "ub": 0.01, "index": 11}
+  - {"ground_truth": 7.706062793082981e-05, "lb": 1e-05, "ub": 0.01, "index": 12}
+  - {"ground_truth": 0.008691324429020193, "lb": 1e-05, "ub": 0.01, "index": 13}
+  - {"ground_truth": 0.0014445830094055269, "lb": 1e-05, "ub": 0.01, "index": 14}
+  - {"ground_truth": 0.0001244441628555007, "lb": 1e-05, "ub": 0.01, "index": 15}
+  - {"ground_truth": 0.007453296965432761, "lb": 1e-05, "ub": 0.01, "index": 16}
+  - {"ground_truth": 0.008799113445489297, "lb": 1e-05, "ub": 0.01, "index": 17}
+  - {"ground_truth": 0.0003934024741723284, "lb": 1e-05, "ub": 0.01, "index": 18}
+  - {"ground_truth": 5.620547124633913e-05, "lb": 1e-05, "ub": 0.01, "index": 19}
+  - {"ground_truth": 0.002449720226286379, "lb": 1e-05, "ub": 0.01, "index": 20}
+  - {"ground_truth": 4.556566498892201e-05, "lb": 1e-05, "ub": 0.01, "index": 21}
+  - {"ground_truth": 1.0291366001813238e-05, "lb": 1e-05, "ub": 0.01, "index": 22}
+  - {"ground_truth": 5.942718356120848e-05, "lb": 1e-05, "ub": 0.01, "index": 23}
+  - {"ground_truth": 7.895433941807506e-05, "lb": 1e-05, "ub": 0.01, "index": 24}
+  - {"ground_truth": 2.4655036978916396e-05, "lb": 1e-05, "ub": 0.01, "index": 25}
+  - {"ground_truth": 5.641244988008681e-05, "lb": 1e-05, "ub": 0.01, "index": 26}
+  - {"ground_truth": 0.0005496186797839989, "lb": 1e-05, "ub": 0.01, "index": 27}
+  - {"ground_truth": 0.0002442364215847237, "lb": 1e-05, "ub": 0.01, "index": 28}
+  - {"ground_truth": 9.039964909436815e-05, "lb": 1e-05, "ub": 0.01, "index": 29}
+  - {"ground_truth": 0.0003099379267392234, "lb": 1e-05, "ub": 0.01, "index": 30}
+  - {"ground_truth": 3.5044324392258984e-05, "lb": 1e-05, "ub": 0.01, "index": 31}
+  - {"ground_truth": 8.68977823704281e-05, "lb": 1e-05, "ub": 0.01, "index": 32}
+  - {"ground_truth": 6.598111996737249e-05, "lb": 1e-05, "ub": 0.01, "index": 33}
+  - {"ground_truth": 0.0001268317077344063, "lb": 1e-05, "ub": 0.01, "index": 34}
+  - {"ground_truth": 0.0017958472097867402, "lb": 1e-05, "ub": 0.01, "index": 35}
+  - {"ground_truth": 0.00511094010497419, "lb": 1e-05, "ub": 0.01, "index": 36}
+  - {"ground_truth": 0.0007086552427081451, "lb": 1e-05, "ub": 0.01, "index": 37}
+  - {"ground_truth": 0.0005339865898496273, "lb": 1e-05, "ub": 0.01, "index": 38}
+  - {"ground_truth": 0.000875914857887453, "lb": 1e-05, "ub": 0.01, "index": 39}
+  - {"ground_truth": 0.0001849463656004242, "lb": 1e-05, "ub": 0.01, "index": 40}
+  - {"ground_truth": 3.829076775526719e-05, "lb": 1e-05, "ub": 0.01, "index": 41}
+  - {"ground_truth": 0.0015708319631987423, "lb": 1e-05, "ub": 0.01, "index": 42}
+  - {"ground_truth": 0.0003889260284959057, "lb": 1e-05, "ub": 0.01, "index": 43}
+  - {"ground_truth": 8.306624072392709e-05, "lb": 1e-05, "ub": 0.01, "index": 44}
+  - {"ground_truth": 2.478789923615565e-05, "lb": 1e-05, "ub": 0.01, "index": 45}
+  - {"ground_truth": 0.00029760232157877435, "lb": 1e-05, "ub": 0.01, "index": 46}
+  - {"ground_truth": 2.7152865488279057e-05, "lb": 1e-05, "ub": 0.01, "index": 47}
+  - {"ground_truth": 7.649770462411239e-05, "lb": 1e-05, "ub": 0.01, "index": 48}
+  - {"ground_truth": 0.006509845911451317, "lb": 1e-05, "ub": 0.01, "index": 49}
+  - {"ground_truth": 7.658828630610365e-05, "lb": 1e-05, "ub": 0.01, "index": 50}
+  - {"ground_truth": 0.0011452041358598355, "lb": 1e-05, "ub": 0.01, "index": 51}
+  - {"ground_truth": 0.0008615563010281715, "lb": 1e-05, "ub": 0.01, "index": 52}
+  - {"ground_truth": 0.00937120216704011, "lb": 1e-05, "ub": 0.01, "index": 53}
+  - {"ground_truth": 8.688159947187885e-05, "lb": 1e-05, "ub": 0.01, "index": 54}
+  - {"ground_truth": 0.0003343984343148916, "lb": 1e-05, "ub": 0.01, "index": 55}
+  - {"ground_truth": 0.0005770302974943314, "lb": 1e-05, "ub": 0.01, "index": 56}
+  - {"ground_truth": 6.342877075796101e-05, "lb": 1e-05, "ub": 0.01, "index": 57}
+  - {"ground_truth": 0.0005221159409091538, "lb": 1e-05, "ub": 0.01, "index": 58}
+  - {"ground_truth": 0.00034622379768388265, "lb": 1e-05, "ub": 0.01, "index": 59}
+  - {"ground_truth": 0.0097543307299165, "lb": 1e-05, "ub": 0.01, "index": 60}
+  - {"ground_truth": 6.166215877718817e-05, "lb": 1e-05, "ub": 0.01, "index": 61}
+  - {"ground_truth": 0.0004646258648173351, "lb": 1e-05, "ub": 0.01, "index": 62}
+epochTimeSplit:
+populationConversion:

--- a/examples/5deme1epoch.yaml
+++ b/examples/5deme1epoch.yaml
@@ -1,91 +1,48 @@
 ploidy: 2
+pop_count: 5
 coalescence:
-  vectors:
-  - [1, 2, 3, 4, 5]
+  entries:
+  - {"epoch": 0, "deme": 0, "rate": {"param": 1}}
+  - {"epoch": 0, "deme": 1, "rate": {"param": 2}}
+  - {"epoch": 0, "deme": 2, "rate": {"param": 3}}
+  - {"epoch": 0, "deme": 3, "rate": {"param": 4}}
+  - {"epoch": 0, "deme": 4, "rate": {"param": 5}}
   parameters:
-  - ground_truth: 5.077924e-04
-    lb: 1.0e-05
-    ub: 0.01
-    index: 1
-  - ground_truth: 8.364338e-04
-    lb: 1.0e-05
-    ub: 0.01
-    index: 2
-  - ground_truth: 8.779979e-05
-    lb: 1.0e-05
-    ub: 0.01
-    index: 3
-  - ground_truth: 5.430444e-05
-    lb: 1.0e-05
-    ub: 0.01
-    index: 4
-  - ground_truth: 5.430444e-04
-    lb: 1.0e-05
-    ub: 0.01
-    index: 5
-epochTimeSplit: null
+  - {"ground_truth": 0.0005077924, "lb": 1e-05, "ub": 0.01, "index": 1}
+  - {"ground_truth": 0.0008364338, "lb": 1e-05, "ub": 0.01, "index": 2}
+  - {"ground_truth": 8.779979e-05, "lb": 1e-05, "ub": 0.01, "index": 3}
+  - {"ground_truth": 5.430444e-05, "lb": 1e-05, "ub": 0.01, "index": 4}
+  - {"ground_truth": 0.0005430444, "lb": 1e-05, "ub": 0.01, "index": 5}
 migration:
-  matrices:
-  - [ [ 0,  1,  0,  2,  3],
-      [ 4,  0,  0,  5,  6],
-      [ 0,  0,  0,  7,  8],
-      [ 9, 10, 11,  0,  0],
-      [12, 13, 14,  0,  0] ]
+  entries:
+  - {"epoch": 0, "source": 0, "dest": 1, "rate": {"param": 1}}
+  - {"epoch": 0, "source": 0, "dest": 3, "rate": {"param": 2}}
+  - {"epoch": 0, "source": 0, "dest": 4, "rate": {"param": 3}}
+  - {"epoch": 0, "source": 1, "dest": 0, "rate": {"param": 4}}
+  - {"epoch": 0, "source": 1, "dest": 3, "rate": {"param": 5}}
+  - {"epoch": 0, "source": 1, "dest": 4, "rate": {"param": 6}}
+  - {"epoch": 0, "source": 2, "dest": 3, "rate": {"param": 7}}
+  - {"epoch": 0, "source": 2, "dest": 4, "rate": {"param": 8}}
+  - {"epoch": 0, "source": 3, "dest": 0, "rate": {"param": 9}}
+  - {"epoch": 0, "source": 3, "dest": 1, "rate": {"param": 10}}
+  - {"epoch": 0, "source": 3, "dest": 2, "rate": {"param": 11}}
+  - {"epoch": 0, "source": 4, "dest": 0, "rate": {"param": 12}}
+  - {"epoch": 0, "source": 4, "dest": 1, "rate": {"param": 13}}
+  - {"epoch": 0, "source": 4, "dest": 2, "rate": {"param": 14}}
   parameters:
-  - ground_truth: 1.590209e-04
-    lb: 1.0e-05
-    ub: 0.01
-    index: 1
-  - ground_truth: 2.387828e-03
-    lb: 1.0e-05
-    ub: 0.01
-    index: 2
-  - ground_truth: 1.786017e-03
-    lb: 1.0e-05
-    ub: 0.01
-    index: 3
-  - ground_truth: 3.983939e-04
-    lb: 1.0e-05
-    ub: 0.01
-    index: 4
-  - ground_truth: 5.558405e-04
-    lb: 1.0e-05
-    ub: 0.01
-    index: 5
-  - ground_truth: 4.721602e-04
-    lb: 1.0e-05
-    ub: 0.01
-    index: 6
-  - ground_truth: 8.231606e-05
-    lb: 1.0e-05
-    ub: 0.01
-    index: 7
-  - ground_truth: 1.266172e-04
-    lb: 1.0e-05
-    ub: 0.01
-    index: 8
-  - ground_truth: 2.765965e-04
-    lb: 1.0e-05
-    ub: 0.01
-    index: 9
-  - ground_truth: 9.140634e-05
-    lb: 1.0e-05
-    ub: 0.01
-    index: 10
-  - ground_truth: 1.543894e-03
-    lb: 1.0e-05
-    ub: 0.01
-    index: 11
-  - ground_truth: 7.754050e-05
-    lb: 1.0e-05
-    ub: 0.01
-    index: 12
-  - ground_truth: 8.950423e-05
-    lb: 1.0e-05
-    ub: 0.01
-    index: 13
-  - ground_truth: 6.940905e-05
-    lb: 1.0e-05
-    ub: 0.01
-    index: 14
-populationConversion: null
+  - {"ground_truth": 0.0001590209, "lb": 1e-05, "ub": 0.01, "index": 1}
+  - {"ground_truth": 0.002387828, "lb": 1e-05, "ub": 0.01, "index": 2}
+  - {"ground_truth": 0.001786017, "lb": 1e-05, "ub": 0.01, "index": 3}
+  - {"ground_truth": 0.0003983939, "lb": 1e-05, "ub": 0.01, "index": 4}
+  - {"ground_truth": 0.0005558405, "lb": 1e-05, "ub": 0.01, "index": 5}
+  - {"ground_truth": 0.0004721602, "lb": 1e-05, "ub": 0.01, "index": 6}
+  - {"ground_truth": 8.231606e-05, "lb": 1e-05, "ub": 0.01, "index": 7}
+  - {"ground_truth": 0.0001266172, "lb": 1e-05, "ub": 0.01, "index": 8}
+  - {"ground_truth": 0.0002765965, "lb": 1e-05, "ub": 0.01, "index": 9}
+  - {"ground_truth": 9.140634e-05, "lb": 1e-05, "ub": 0.01, "index": 10}
+  - {"ground_truth": 0.001543894, "lb": 1e-05, "ub": 0.01, "index": 11}
+  - {"ground_truth": 7.75405e-05, "lb": 1e-05, "ub": 0.01, "index": 12}
+  - {"ground_truth": 8.950423e-05, "lb": 1e-05, "ub": 0.01, "index": 13}
+  - {"ground_truth": 6.940905e-05, "lb": 1e-05, "ub": 0.01, "index": 14}
+epochTimeSplit:
+populationConversion:

--- a/examples/5deme2epoch.diffcoal.yaml
+++ b/examples/5deme2epoch.diffcoal.yaml
@@ -1,134 +1,76 @@
-# This model corresponds to eg_2epoch_2mig2_diffcoal from the original Matlab code.
 ploidy: 2
+pop_count: 5
 coalescence:
-  vectors:
-  - [1, 2, 3, 4, 5]
-  - [6, 7, 8, 9, 10]
+  entries:
+  - {"epoch": 0, "deme": 0, "rate": {"param": 1}}
+  - {"epoch": 0, "deme": 1, "rate": {"param": 2}}
+  - {"epoch": 0, "deme": 2, "rate": {"param": 3}}
+  - {"epoch": 0, "deme": 3, "rate": {"param": 4}}
+  - {"epoch": 0, "deme": 4, "rate": {"param": 5}}
+  - {"epoch": 1, "deme": 0, "rate": {"param": 6}}
+  - {"epoch": 1, "deme": 1, "rate": {"param": 7}}
+  - {"epoch": 1, "deme": 2, "rate": {"param": 8}}
+  - {"epoch": 1, "deme": 3, "rate": {"param": 9}}
+  - {"epoch": 1, "deme": 4, "rate": {"param": 10}}
   parameters:
-  - ground_truth: 0.000928253983053902
-    lb: 1.0e-05
-    ub: 0.01
-    index: 1
-  - ground_truth: 0.000228132968232830
-    lb: 1.0e-05
-    ub: 0.01
-    index: 2
-  - ground_truth: 0.000259410999529073
-    lb: 1.0e-05
-    ub: 0.01
-    index: 3
-  - ground_truth: 0.000904972346892899
-    lb: 1.0e-05
-    ub: 0.01
-    index: 4
-  - ground_truth: 0.000352062165327977
-    lb: 1.0e-05
-    ub: 0.01
-    index: 5
-  - ground_truth: 5.077924e-04
-    lb: 1.0e-05
-    ub: 0.01
-    index: 6
-  - ground_truth: 8.364338e-04
-    lb: 1.0e-05
-    ub: 0.01
-    index: 7
-  - ground_truth: 8.779979e-05
-    lb: 1.0e-05
-    ub: 0.01
-    index: 8
-  - ground_truth: 5.430444e-05
-    lb: 1.0e-05
-    ub: 0.01
-    index: 9
-  - ground_truth: 5.430444e-04
-    lb: 1.0e-05
-    ub: 0.01
-    index: 10
-
-epochTimeSplit: 
-- ground_truth: 2.239800e+03
-  lb: 1.0e+03
-  ub: 1.0e+04
-  index: 1
+  - {"ground_truth": 0.000928253983053902, "lb": 1e-05, "ub": 0.01, "index": 1}
+  - {"ground_truth": 0.00022813296823283, "lb": 1e-05, "ub": 0.01, "index": 2}
+  - {"ground_truth": 0.000259410999529073, "lb": 1e-05, "ub": 0.01, "index": 3}
+  - {"ground_truth": 0.000904972346892899, "lb": 1e-05, "ub": 0.01, "index": 4}
+  - {"ground_truth": 0.000352062165327977, "lb": 1e-05, "ub": 0.01, "index": 5}
+  - {"ground_truth": 0.0005077924, "lb": 1e-05, "ub": 0.01, "index": 6}
+  - {"ground_truth": 0.0008364338, "lb": 1e-05, "ub": 0.01, "index": 7}
+  - {"ground_truth": 8.779979e-05, "lb": 1e-05, "ub": 0.01, "index": 8}
+  - {"ground_truth": 5.430444e-05, "lb": 1e-05, "ub": 0.01, "index": 9}
+  - {"ground_truth": 0.0005430444, "lb": 1e-05, "ub": 0.01, "index": 10}
 migration:
-  matrices:
-  - [ [ 0,  1,  0,  2,  3],
-      [ 4,  0,  0,  5,  6],
-      [ 0,  0,  0,  7,  8],
-      [ 9, 10, 11,  0,  0],
-      [12, 13, 14,  0,  0] ]
-  - [ [ 0, 15,  0, 15, 15],
-      [15,  0,  0, 15, 16],
-      [ 0,  0,  0, 16, 16],
-      [16, 15, 16,  0,  0],
-      [16, 15, 15,  0,  0] ]
+  entries:
+  - {"epoch": 0, "source": 0, "dest": 1, "rate": {"param": 1}}
+  - {"epoch": 0, "source": 0, "dest": 3, "rate": {"param": 2}}
+  - {"epoch": 0, "source": 0, "dest": 4, "rate": {"param": 3}}
+  - {"epoch": 0, "source": 1, "dest": 0, "rate": {"param": 4}}
+  - {"epoch": 0, "source": 1, "dest": 3, "rate": {"param": 5}}
+  - {"epoch": 0, "source": 1, "dest": 4, "rate": {"param": 6}}
+  - {"epoch": 0, "source": 2, "dest": 3, "rate": {"param": 7}}
+  - {"epoch": 0, "source": 2, "dest": 4, "rate": {"param": 8}}
+  - {"epoch": 0, "source": 3, "dest": 0, "rate": {"param": 9}}
+  - {"epoch": 0, "source": 3, "dest": 1, "rate": {"param": 10}}
+  - {"epoch": 0, "source": 3, "dest": 2, "rate": {"param": 11}}
+  - {"epoch": 0, "source": 4, "dest": 0, "rate": {"param": 12}}
+  - {"epoch": 0, "source": 4, "dest": 1, "rate": {"param": 13}}
+  - {"epoch": 0, "source": 4, "dest": 2, "rate": {"param": 14}}
+  - {"epoch": 1, "source": 0, "dest": 1, "rate": {"param": 15}}
+  - {"epoch": 1, "source": 0, "dest": 3, "rate": {"param": 15}}
+  - {"epoch": 1, "source": 0, "dest": 4, "rate": {"param": 15}}
+  - {"epoch": 1, "source": 1, "dest": 0, "rate": {"param": 15}}
+  - {"epoch": 1, "source": 1, "dest": 3, "rate": {"param": 15}}
+  - {"epoch": 1, "source": 1, "dest": 4, "rate": {"param": 16}}
+  - {"epoch": 1, "source": 2, "dest": 3, "rate": {"param": 16}}
+  - {"epoch": 1, "source": 2, "dest": 4, "rate": {"param": 16}}
+  - {"epoch": 1, "source": 3, "dest": 0, "rate": {"param": 16}}
+  - {"epoch": 1, "source": 3, "dest": 1, "rate": {"param": 15}}
+  - {"epoch": 1, "source": 3, "dest": 2, "rate": {"param": 16}}
+  - {"epoch": 1, "source": 4, "dest": 0, "rate": {"param": 16}}
+  - {"epoch": 1, "source": 4, "dest": 1, "rate": {"param": 15}}
+  - {"epoch": 1, "source": 4, "dest": 2, "rate": {"param": 15}}
   parameters:
-  - ground_truth: 1.590209e-04
-    lb: 1.0e-05
-    ub: 0.01
-    index: 1
-  - ground_truth: 2.387828e-03
-    lb: 1.0e-05
-    ub: 0.01
-    index: 2
-  - ground_truth: 1.786017e-03
-    lb: 1.0e-05
-    ub: 0.01
-    index: 3
-  - ground_truth: 3.983939e-04
-    lb: 1.0e-05
-    ub: 0.01
-    index: 4
-  - ground_truth: 5.558405e-04
-    lb: 1.0e-05
-    ub: 0.01
-    index: 5
-  - ground_truth: 4.721602e-04
-    lb: 1.0e-05
-    ub: 0.01
-    index: 6
-  - ground_truth: 8.231606e-05
-    lb: 1.0e-05
-    ub: 0.01
-    index: 7
-  - ground_truth: 1.266172e-04
-    lb: 1.0e-05
-    ub: 0.01
-    index: 8
-  - ground_truth: 2.765965e-04
-    lb: 1.0e-05
-    ub: 0.01
-    index: 9
-  - ground_truth: 9.140634e-05
-    lb: 1.0e-05
-    ub: 0.01
-    index: 10
-  - ground_truth: 1.543894e-03
-    lb: 1.0e-05
-    ub: 0.01
-    index: 11
-  - ground_truth: 7.754050e-05
-    lb: 1.0e-05
-    ub: 0.01
-    index: 12
-  - ground_truth: 8.950423e-05
-    lb: 1.0e-05
-    ub: 0.01
-    index: 13
-  - ground_truth: 6.940905e-05
-    lb: 1.0e-05
-    ub: 0.01
-    index: 14
-  - ground_truth: 0.000513075854560119
-    lb: 1.0e-05
-    ub: 0.01
-    index: 15
-  - ground_truth: 0.000872774644544434
-    lb: 1.0e-05
-    ub: 0.01
-    index: 16
-
+  - {"ground_truth": 0.0001590209, "lb": 1e-05, "ub": 0.01, "index": 1}
+  - {"ground_truth": 0.002387828, "lb": 1e-05, "ub": 0.01, "index": 2}
+  - {"ground_truth": 0.001786017, "lb": 1e-05, "ub": 0.01, "index": 3}
+  - {"ground_truth": 0.0003983939, "lb": 1e-05, "ub": 0.01, "index": 4}
+  - {"ground_truth": 0.0005558405, "lb": 1e-05, "ub": 0.01, "index": 5}
+  - {"ground_truth": 0.0004721602, "lb": 1e-05, "ub": 0.01, "index": 6}
+  - {"ground_truth": 8.231606e-05, "lb": 1e-05, "ub": 0.01, "index": 7}
+  - {"ground_truth": 0.0001266172, "lb": 1e-05, "ub": 0.01, "index": 8}
+  - {"ground_truth": 0.0002765965, "lb": 1e-05, "ub": 0.01, "index": 9}
+  - {"ground_truth": 9.140634e-05, "lb": 1e-05, "ub": 0.01, "index": 10}
+  - {"ground_truth": 0.001543894, "lb": 1e-05, "ub": 0.01, "index": 11}
+  - {"ground_truth": 7.75405e-05, "lb": 1e-05, "ub": 0.01, "index": 12}
+  - {"ground_truth": 8.950423e-05, "lb": 1e-05, "ub": 0.01, "index": 13}
+  - {"ground_truth": 6.940905e-05, "lb": 1e-05, "ub": 0.01, "index": 14}
+  - {"ground_truth": 0.000513075854560119, "lb": 1e-05, "ub": 0.01, "index": 15}
+  - {"ground_truth": 0.000872774644544434, "lb": 1e-05, "ub": 0.01, "index": 16}
+epochTimeSplit:
+- {"ground_truth": 2239.8, "lb": 1000.0, "ub": 10000.0, "index": 1}
 populationConversion:
-  # Epoch 1 -> Epoch 2, the population structure stays constant.
-  - [0, 1, 2, 3, 4]
+- [0, 1, 2, 3, 4]

--- a/examples/5deme2epoch.yaml
+++ b/examples/5deme2epoch.yaml
@@ -1,108 +1,70 @@
-# This model corresponds to eg_2epoch_simpleMig2 from the original Matlab code.
 ploidy: 2
+pop_count: 5
 coalescence:
-  vectors:
-  - [1, 2, 3, 4, 5]
-  - [1, 2, 3, 4, 5]
+  entries:
+  - {"epoch": 0, "deme": 0, "rate": {"param": 1}}
+  - {"epoch": 0, "deme": 1, "rate": {"param": 2}}
+  - {"epoch": 0, "deme": 2, "rate": {"param": 3}}
+  - {"epoch": 0, "deme": 3, "rate": {"param": 4}}
+  - {"epoch": 0, "deme": 4, "rate": {"param": 5}}
+  - {"epoch": 1, "deme": 0, "rate": {"param": 1}}
+  - {"epoch": 1, "deme": 1, "rate": {"param": 2}}
+  - {"epoch": 1, "deme": 2, "rate": {"param": 3}}
+  - {"epoch": 1, "deme": 3, "rate": {"param": 4}}
+  - {"epoch": 1, "deme": 4, "rate": {"param": 5}}
   parameters:
-  - ground_truth: 5.077924e-04
-    lb: 1.0e-05
-    ub: 0.01
-    index: 1
-  - ground_truth: 8.364338e-04
-    lb: 1.0e-05
-    ub: 0.01
-    index: 2
-  - ground_truth: 8.779979e-05
-    lb: 1.0e-05
-    ub: 0.01
-    index: 3
-  - ground_truth: 5.430444e-05
-    lb: 1.0e-05
-    ub: 0.01
-    index: 4
-  - ground_truth: 5.430444e-04
-    lb: 1.0e-05
-    ub: 0.01
-    index: 5
-epochTimeSplit: 
-- ground_truth: 2.239800e+03
-  lb: 1.0e+03
-  ub: 1.0e+04
-  index: 1
+  - {"ground_truth": 0.0005077924, "lb": 1e-05, "ub": 0.01, "index": 1}
+  - {"ground_truth": 0.0008364338, "lb": 1e-05, "ub": 0.01, "index": 2}
+  - {"ground_truth": 8.779979e-05, "lb": 1e-05, "ub": 0.01, "index": 3}
+  - {"ground_truth": 5.430444e-05, "lb": 1e-05, "ub": 0.01, "index": 4}
+  - {"ground_truth": 0.0005430444, "lb": 1e-05, "ub": 0.01, "index": 5}
 migration:
-  matrices:
-  - [ [ 0,  1,  0,  2,  3],
-      [ 4,  0,  0,  5,  6],
-      [ 0,  0,  0,  7,  8],
-      [ 9, 10, 11,  0,  0],
-      [12, 13, 14,  0,  0] ]
-  - [ [ 0, 15,  0, 15, 15],
-      [15,  0,  0, 15, 15],
-      [ 0,  0,  0, 15, 15],
-      [15, 15, 15,  0,  0],
-      [15, 15, 15,  0,  0] ]
+  entries:
+  - {"epoch": 0, "source": 0, "dest": 1, "rate": {"param": 1}}
+  - {"epoch": 0, "source": 0, "dest": 3, "rate": {"param": 2}}
+  - {"epoch": 0, "source": 0, "dest": 4, "rate": {"param": 3}}
+  - {"epoch": 0, "source": 1, "dest": 0, "rate": {"param": 4}}
+  - {"epoch": 0, "source": 1, "dest": 3, "rate": {"param": 5}}
+  - {"epoch": 0, "source": 1, "dest": 4, "rate": {"param": 6}}
+  - {"epoch": 0, "source": 2, "dest": 3, "rate": {"param": 7}}
+  - {"epoch": 0, "source": 2, "dest": 4, "rate": {"param": 8}}
+  - {"epoch": 0, "source": 3, "dest": 0, "rate": {"param": 9}}
+  - {"epoch": 0, "source": 3, "dest": 1, "rate": {"param": 10}}
+  - {"epoch": 0, "source": 3, "dest": 2, "rate": {"param": 11}}
+  - {"epoch": 0, "source": 4, "dest": 0, "rate": {"param": 12}}
+  - {"epoch": 0, "source": 4, "dest": 1, "rate": {"param": 13}}
+  - {"epoch": 0, "source": 4, "dest": 2, "rate": {"param": 14}}
+  - {"epoch": 1, "source": 0, "dest": 1, "rate": {"param": 15}}
+  - {"epoch": 1, "source": 0, "dest": 3, "rate": {"param": 15}}
+  - {"epoch": 1, "source": 0, "dest": 4, "rate": {"param": 15}}
+  - {"epoch": 1, "source": 1, "dest": 0, "rate": {"param": 15}}
+  - {"epoch": 1, "source": 1, "dest": 3, "rate": {"param": 15}}
+  - {"epoch": 1, "source": 1, "dest": 4, "rate": {"param": 15}}
+  - {"epoch": 1, "source": 2, "dest": 3, "rate": {"param": 15}}
+  - {"epoch": 1, "source": 2, "dest": 4, "rate": {"param": 15}}
+  - {"epoch": 1, "source": 3, "dest": 0, "rate": {"param": 15}}
+  - {"epoch": 1, "source": 3, "dest": 1, "rate": {"param": 15}}
+  - {"epoch": 1, "source": 3, "dest": 2, "rate": {"param": 15}}
+  - {"epoch": 1, "source": 4, "dest": 0, "rate": {"param": 15}}
+  - {"epoch": 1, "source": 4, "dest": 1, "rate": {"param": 15}}
+  - {"epoch": 1, "source": 4, "dest": 2, "rate": {"param": 15}}
   parameters:
-  - ground_truth: 1.590209e-04
-    lb: 1.0e-05
-    ub: 0.01
-    index: 1
-  - ground_truth: 2.387828e-03
-    lb: 1.0e-05
-    ub: 0.01
-    index: 2
-  - ground_truth: 1.786017e-03
-    lb: 1.0e-05
-    ub: 0.01
-    index: 3
-  - ground_truth: 3.983939e-04
-    lb: 1.0e-05
-    ub: 0.01
-    index: 4
-  - ground_truth: 5.558405e-04
-    lb: 1.0e-05
-    ub: 0.01
-    index: 5
-  - ground_truth: 4.721602e-04
-    lb: 1.0e-05
-    ub: 0.01
-    index: 6
-  - ground_truth: 8.231606e-05
-    lb: 1.0e-05
-    ub: 0.01
-    index: 7
-  - ground_truth: 1.266172e-04
-    lb: 1.0e-05
-    ub: 0.01
-    index: 8
-  - ground_truth: 2.765965e-04
-    lb: 1.0e-05
-    ub: 0.01
-    index: 9
-  - ground_truth: 9.140634e-05
-    lb: 1.0e-05
-    ub: 0.01
-    index: 10
-  - ground_truth: 1.543894e-03
-    lb: 1.0e-05
-    ub: 0.01
-    index: 11
-  - ground_truth: 7.754050e-05
-    lb: 1.0e-05
-    ub: 0.01
-    index: 12
-  - ground_truth: 8.950423e-05
-    lb: 1.0e-05
-    ub: 0.01
-    index: 13
-  - ground_truth: 6.940905e-05
-    lb: 1.0e-05
-    ub: 0.01
-    index: 14
-  - ground_truth: 9.022535e-05
-    lb: 1.0e-05
-    ub: 0.01
-    index: 15
+  - {"ground_truth": 0.0001590209, "lb": 1e-05, "ub": 0.01, "index": 1}
+  - {"ground_truth": 0.002387828, "lb": 1e-05, "ub": 0.01, "index": 2}
+  - {"ground_truth": 0.001786017, "lb": 1e-05, "ub": 0.01, "index": 3}
+  - {"ground_truth": 0.0003983939, "lb": 1e-05, "ub": 0.01, "index": 4}
+  - {"ground_truth": 0.0005558405, "lb": 1e-05, "ub": 0.01, "index": 5}
+  - {"ground_truth": 0.0004721602, "lb": 1e-05, "ub": 0.01, "index": 6}
+  - {"ground_truth": 8.231606e-05, "lb": 1e-05, "ub": 0.01, "index": 7}
+  - {"ground_truth": 0.0001266172, "lb": 1e-05, "ub": 0.01, "index": 8}
+  - {"ground_truth": 0.0002765965, "lb": 1e-05, "ub": 0.01, "index": 9}
+  - {"ground_truth": 9.140634e-05, "lb": 1e-05, "ub": 0.01, "index": 10}
+  - {"ground_truth": 0.001543894, "lb": 1e-05, "ub": 0.01, "index": 11}
+  - {"ground_truth": 7.75405e-05, "lb": 1e-05, "ub": 0.01, "index": 12}
+  - {"ground_truth": 8.950423e-05, "lb": 1e-05, "ub": 0.01, "index": 13}
+  - {"ground_truth": 6.940905e-05, "lb": 1e-05, "ub": 0.01, "index": 14}
+  - {"ground_truth": 9.022535e-05, "lb": 1e-05, "ub": 0.01, "index": 15}
+epochTimeSplit:
+- {"ground_truth": 2239.8, "lb": 1000.0, "ub": 10000.0, "index": 1}
 populationConversion:
-  # Epoch 1 -> Epoch 2, the population structure stays constant.
-  - [0, 1, 2, 3, 4]
+- [0, 1, 2, 3, 4]

--- a/examples/6deme1epoch.yaml
+++ b/examples/6deme1epoch.yaml
@@ -1,98 +1,50 @@
-# Ported from coalMatrixForMSPrime2by3.txt and migMatrixForMSPrime2by3.txt. All rates
-# were divided by 2000 (as implied by msprimeTest2by3.py).
 ploidy: 2
+pop_count: 6
 coalescence:
-  vectors:
-  - [1, 2, 3, 4, 5, 6]
+  entries:
+  - {"epoch": 0, "deme": 0, "rate": {"param": 1}}
+  - {"epoch": 0, "deme": 1, "rate": {"param": 2}}
+  - {"epoch": 0, "deme": 2, "rate": {"param": 3}}
+  - {"epoch": 0, "deme": 3, "rate": {"param": 4}}
+  - {"epoch": 0, "deme": 4, "rate": {"param": 5}}
+  - {"epoch": 0, "deme": 5, "rate": {"param": 6}}
   parameters:
-  - ground_truth: 0.003397462
-    lb: 1.0e-05
-    ub: 0.01
-    index: 1
-  - ground_truth: 0.002974771
-    lb: 1.0e-05
-    ub: 0.01
-    index: 2
-  - ground_truth: 0.0001687103
-    lb: 1.0e-05
-    ub: 0.01
-    index: 3
-  - ground_truth: 0.0028163274
-    lb: 1.0e-05
-    ub: 0.01
-    index: 4
-  - ground_truth: 0.0013332995
-    lb: 1.0e-05
-    ub: 0.01
-    index: 5
-  - ground_truth: 0.0021047509
-    lb: 1.0e-05
-    ub: 0.01
-    index: 6
-epochTimeSplit: null
+  - {"ground_truth": 0.003397462, "lb": 1e-05, "ub": 0.01, "index": 1}
+  - {"ground_truth": 0.002974771, "lb": 1e-05, "ub": 0.01, "index": 2}
+  - {"ground_truth": 0.0001687103, "lb": 1e-05, "ub": 0.01, "index": 3}
+  - {"ground_truth": 0.0028163274, "lb": 1e-05, "ub": 0.01, "index": 4}
+  - {"ground_truth": 0.0013332995, "lb": 1e-05, "ub": 0.01, "index": 5}
+  - {"ground_truth": 0.0021047509, "lb": 1e-05, "ub": 0.01, "index": 6}
 migration:
-  matrices:
-  - [ [ 0,  1,  0,  2,  0,  0],
-      [ 3,  0,  4,  0,  5,  0],
-      [ 0,  6,  0,  0,  0,  7],
-      [ 8,  0,  0,  0,  9,  0],
-      [ 0, 10,  0, 11,  0, 12],
-      [ 0,  0, 13,  0, 14,  0] ]
+  entries:
+  - {"epoch": 0, "source": 0, "dest": 1, "rate": {"param": 1}}
+  - {"epoch": 0, "source": 0, "dest": 3, "rate": {"param": 2}}
+  - {"epoch": 0, "source": 1, "dest": 0, "rate": {"param": 3}}
+  - {"epoch": 0, "source": 1, "dest": 2, "rate": {"param": 4}}
+  - {"epoch": 0, "source": 1, "dest": 4, "rate": {"param": 5}}
+  - {"epoch": 0, "source": 2, "dest": 1, "rate": {"param": 6}}
+  - {"epoch": 0, "source": 2, "dest": 5, "rate": {"param": 7}}
+  - {"epoch": 0, "source": 3, "dest": 0, "rate": {"param": 8}}
+  - {"epoch": 0, "source": 3, "dest": 4, "rate": {"param": 9}}
+  - {"epoch": 0, "source": 4, "dest": 1, "rate": {"param": 10}}
+  - {"epoch": 0, "source": 4, "dest": 3, "rate": {"param": 11}}
+  - {"epoch": 0, "source": 4, "dest": 5, "rate": {"param": 12}}
+  - {"epoch": 0, "source": 5, "dest": 2, "rate": {"param": 13}}
+  - {"epoch": 0, "source": 5, "dest": 4, "rate": {"param": 14}}
   parameters:
-  - ground_truth: 0.0027764495
-    lb: 1.0e-05
-    ub: 0.01
-    index: 1
-  - ground_truth: 0.0035553315
-    lb: 1.0e-05
-    ub: 0.01
-    index: 2
-  - ground_truth: 0.0014899785
-    lb: 1.0e-05
-    ub: 0.01
-    index: 3
-  - ground_truth: 0.0025785965
-    lb: 1.0e-05
-    ub: 0.01
-    index: 4
-  - ground_truth: 0.0044700875
-    lb: 1.0e-05
-    ub: 0.01
-    index: 5
-  - ground_truth: 0.004486651
-    lb: 1.0e-05
-    ub: 0.01
-    index: 6
-  - ground_truth: 0.0006716475
-    lb: 1.0e-05
-    ub: 0.01
-    index: 7
-  - ground_truth: 0.001075852
-    lb: 1.0e-05
-    ub: 0.01
-    index: 8
-  - ground_truth: 0.00030476265000000004
-    lb: 1.0e-05
-    ub: 0.01
-    index: 9
-  - ground_truth: 0.0022320085
-    lb: 1.0e-05
-    ub: 0.01
-    index: 10
-  - ground_truth: 0.00019788724999999997
-    lb: 1.0e-05
-    ub: 0.01
-    index: 11
-  - ground_truth: 0.0023113245
-    lb: 1.0e-05
-    ub: 0.01
-    index: 12
-  - ground_truth: 0.0032632629999999998
-    lb: 1.0e-05
-    ub: 0.01
-    index: 13
-  - ground_truth: 0.001428512
-    lb: 1.0e-05
-    ub: 0.01
-    index: 14
-populationConversion: null
+  - {"ground_truth": 0.0027764495, "lb": 1e-05, "ub": 0.01, "index": 1}
+  - {"ground_truth": 0.0035553315, "lb": 1e-05, "ub": 0.01, "index": 2}
+  - {"ground_truth": 0.0014899785, "lb": 1e-05, "ub": 0.01, "index": 3}
+  - {"ground_truth": 0.0025785965, "lb": 1e-05, "ub": 0.01, "index": 4}
+  - {"ground_truth": 0.0044700875, "lb": 1e-05, "ub": 0.01, "index": 5}
+  - {"ground_truth": 0.004486651, "lb": 1e-05, "ub": 0.01, "index": 6}
+  - {"ground_truth": 0.0006716475, "lb": 1e-05, "ub": 0.01, "index": 7}
+  - {"ground_truth": 0.001075852, "lb": 1e-05, "ub": 0.01, "index": 8}
+  - {"ground_truth": 0.00030476265000000004, "lb": 1e-05, "ub": 0.01, "index": 9}
+  - {"ground_truth": 0.0022320085, "lb": 1e-05, "ub": 0.01, "index": 10}
+  - {"ground_truth": 0.00019788724999999997, "lb": 1e-05, "ub": 0.01, "index": 11}
+  - {"ground_truth": 0.0023113245, "lb": 1e-05, "ub": 0.01, "index": 12}
+  - {"ground_truth": 0.0032632629999999998, "lb": 1e-05, "ub": 0.01, "index": 13}
+  - {"ground_truth": 0.001428512, "lb": 1e-05, "ub": 0.01, "index": 14}
+epochTimeSplit:
+populationConversion:

--- a/examples/6deme2epoch.split.yaml
+++ b/examples/6deme2epoch.split.yaml
@@ -1,115 +1,54 @@
 ploidy: 2
+pop_count: 7
 coalescence:
-  vectors:
-  - [1, 2, 3, 4, 5, 6, 0]
-  - [0, 0, 0, 0, 0, 0, 7]
+  entries:
+  - {"epoch": 0, "deme": 0, "rate": {"param": 1}}
+  - {"epoch": 0, "deme": 1, "rate": {"param": 2}}
+  - {"epoch": 0, "deme": 2, "rate": {"param": 3}}
+  - {"epoch": 0, "deme": 3, "rate": {"param": 4}}
+  - {"epoch": 0, "deme": 4, "rate": {"param": 5}}
+  - {"epoch": 0, "deme": 5, "rate": {"param": 6}}
+  - {"epoch": 1, "deme": 6, "rate": {"param": 7}}
   parameters:
-  - ground_truth: 6.446482873031109e-05
-    lb: 1.0e-05
-    ub: 0.01
-    index: 1
-  - ground_truth: 0.0008009314586890395
-    lb: 1.0e-05
-    ub: 0.01
-    index: 2
-  - ground_truth: 0.0008957316907765961
-    lb: 1.0e-05
-    ub: 0.01
-    index: 3
-  - ground_truth: 0.0006867308124017574
-    lb: 1.0e-05
-    ub: 0.01
-    index: 4
-  - ground_truth: 0.00010430672528550718
-    lb: 1.0e-05
-    ub: 0.01
-    index: 5
-  - ground_truth: 0.0016066220136394323
-    lb: 1.0e-05
-    ub: 0.01
-    index: 6
-  - ground_truth: 0.0002133016
-    lb: 1.0e-05
-    ub: 0.01
-    index: 7
+  - {"ground_truth": 6.446482873031109e-05, "lb": 1e-05, "ub": 0.01, "index": 1}
+  - {"ground_truth": 0.0008009314586890395, "lb": 1e-05, "ub": 0.01, "index": 2}
+  - {"ground_truth": 0.0008957316907765961, "lb": 1e-05, "ub": 0.01, "index": 3}
+  - {"ground_truth": 0.0006867308124017574, "lb": 1e-05, "ub": 0.01, "index": 4}
+  - {"ground_truth": 0.00010430672528550718, "lb": 1e-05, "ub": 0.01, "index": 5}
+  - {"ground_truth": 0.0016066220136394323, "lb": 1e-05, "ub": 0.01, "index": 6}
+  - {"ground_truth": 0.0002133016, "lb": 1e-05, "ub": 0.01, "index": 7}
 migration:
-  matrices:
-  - [ [0, 1, 0, 2, 0, 0, 0],
-      [3, 0, 4, 0, 5, 0, 0],
-      [0, 6, 0, 0, 0, 7, 0],
-      [9, 0, 0, 0, 8, 0, 0],
-      [0, 12, 0, 10, 0, 11, 0],
-      [0, 0, 14, 0, 13, 0, 0],
-      [0, 0, 0, 0, 0, 0, 0] ]
-  - [ [0, 0, 0, 0, 0, 0, 0],
-      [0, 0, 0, 0, 0, 0, 0],
-      [0, 0, 0, 0, 0, 0, 0],
-      [0, 0, 0, 0, 0, 0, 0],
-      [0, 0, 0, 0, 0, 0, 0],
-      [0, 0, 0, 0, 0, 0, 0],
-      [0, 0, 0, 0, 0, 0, 0] ]
+  entries:
+  - {"epoch": 0, "source": 0, "dest": 1, "rate": {"param": 1}}
+  - {"epoch": 0, "source": 0, "dest": 3, "rate": {"param": 2}}
+  - {"epoch": 0, "source": 1, "dest": 0, "rate": {"param": 3}}
+  - {"epoch": 0, "source": 1, "dest": 2, "rate": {"param": 4}}
+  - {"epoch": 0, "source": 1, "dest": 4, "rate": {"param": 5}}
+  - {"epoch": 0, "source": 2, "dest": 1, "rate": {"param": 6}}
+  - {"epoch": 0, "source": 2, "dest": 5, "rate": {"param": 7}}
+  - {"epoch": 0, "source": 3, "dest": 0, "rate": {"param": 9}}
+  - {"epoch": 0, "source": 3, "dest": 4, "rate": {"param": 8}}
+  - {"epoch": 0, "source": 4, "dest": 1, "rate": {"param": 12}}
+  - {"epoch": 0, "source": 4, "dest": 3, "rate": {"param": 10}}
+  - {"epoch": 0, "source": 4, "dest": 5, "rate": {"param": 11}}
+  - {"epoch": 0, "source": 5, "dest": 2, "rate": {"param": 14}}
+  - {"epoch": 0, "source": 5, "dest": 4, "rate": {"param": 13}}
   parameters:
-  - ground_truth: 0.008358954553750823
-    lb: 1.0e-05
-    ub: 0.01
-    index: 1
-  - ground_truth: 0.003915762724032668
-    lb: 1.0e-05
-    ub: 0.01
-    index: 2
-  - ground_truth: 0.00991114687838984
-    lb: 1.0e-05
-    ub: 0.01
-    index: 3
-  - ground_truth: 0.0045634283676066765
-    lb: 1.0e-05
-    ub: 0.01
-    index: 4
-  - ground_truth: 0.006913916973521281
-    lb: 1.0e-05
-    ub: 0.01
-    index: 5
-  - ground_truth: 0.0004772000606606805
-    lb: 1.0e-05
-    ub: 0.01
-    index: 6
-  - ground_truth: 0.0007818530256436477
-    lb: 1.0e-05
-    ub: 0.01
-    index: 7
-  - ground_truth: 0.008073698909350214
-    lb: 1.0e-05
-    ub: 0.01
-    index: 8
-  - ground_truth: 0.009965563628554885
-    lb: 1.0e-05
-    ub: 0.01
-    index: 9
-  - ground_truth: 0.0048183416746066495
-    lb: 1.0e-05
-    ub: 0.01
-    index: 10
-  - ground_truth: 0.008350208435122169
-    lb: 1.0e-05
-    ub: 0.01
-    index: 11
-  - ground_truth: 0.0071613459422729545
-    lb: 1.0e-05
-    ub: 0.01
-    index: 12
-  - ground_truth: 9.206741445884357e-05
-    lb: 1.0e-05
-    ub: 0.01
-    index: 13
-  - ground_truth: 0.005250320005183591
-    lb: 1.0e-05
-    ub: 0.01
-    index: 14
+  - {"ground_truth": 0.008358954553750823, "lb": 1e-05, "ub": 0.01, "index": 1}
+  - {"ground_truth": 0.003915762724032668, "lb": 1e-05, "ub": 0.01, "index": 2}
+  - {"ground_truth": 0.00991114687838984, "lb": 1e-05, "ub": 0.01, "index": 3}
+  - {"ground_truth": 0.0045634283676066765, "lb": 1e-05, "ub": 0.01, "index": 4}
+  - {"ground_truth": 0.006913916973521281, "lb": 1e-05, "ub": 0.01, "index": 5}
+  - {"ground_truth": 0.0004772000606606805, "lb": 1e-05, "ub": 0.01, "index": 6}
+  - {"ground_truth": 0.0007818530256436477, "lb": 1e-05, "ub": 0.01, "index": 7}
+  - {"ground_truth": 0.008073698909350214, "lb": 1e-05, "ub": 0.01, "index": 8}
+  - {"ground_truth": 0.009965563628554885, "lb": 1e-05, "ub": 0.01, "index": 9}
+  - {"ground_truth": 0.0048183416746066495, "lb": 1e-05, "ub": 0.01, "index": 10}
+  - {"ground_truth": 0.008350208435122169, "lb": 1e-05, "ub": 0.01, "index": 11}
+  - {"ground_truth": 0.0071613459422729545, "lb": 1e-05, "ub": 0.01, "index": 12}
+  - {"ground_truth": 9.206741445884357e-05, "lb": 1e-05, "ub": 0.01, "index": 13}
+  - {"ground_truth": 0.005250320005183591, "lb": 1e-05, "ub": 0.01, "index": 14}
+epochTimeSplit:
+- {"ground_truth": 5000.0, "lb": 1000.0, "ub": 10000.0, "index": 1}
 populationConversion:
-  # Epoch 1 -> Epoch 2, the population structure stays constant.
-  - [6, 6, 6, 6, 6, 6, 6]
-epochTimeSplit: 
-- ground_truth: 5.0e+03
-  lb: 1.0e+03
-  ub: 1.0e+04
-  index: 1
+- [6, 6, 6, 6, 6, 6, 6]

--- a/examples/ooa3_tsi.yri_grow.yaml
+++ b/examples/ooa3_tsi.yri_grow.yaml
@@ -1,108 +1,53 @@
-# OutOfAfrica_3G09 from stdpopsim, modified to have a growth rate for YRI in the most recent epoch,
-# and with parameter values as inferred from mrpast+tsinfer on 30 individuals/deme in high-coverage
-# 1,000 Genomes Project dataset.
-# Values take from the median of 100 bootstraps.
 ploidy: 2
+pop_count: 3
 pop_names:
 - YRI
 - CEU
 - CHB
 coalescence:
-  vectors:
-  - [6, 4, 5]
-  - [2, 3, 0]
-  - [2, 0, 0]
-  - [1, 0, 0]
+  entries:
+  - {"epoch": 0, "deme": 0, "rate": {"param": 6}}
+  - {"epoch": 0, "deme": 1, "rate": {"param": 4}}
+  - {"epoch": 0, "deme": 2, "rate": {"param": 5}}
+  - {"epoch": 1, "deme": 0, "rate": {"param": 2}}
+  - {"epoch": 1, "deme": 1, "rate": {"param": 3}}
+  - {"epoch": 2, "deme": 0, "rate": {"param": 2}}
+  - {"epoch": 3, "deme": 0, "rate": {"param": 1}}
   parameters:
-  - ground_truth: 2.9943705833033898e-05
-    lb: 1.0e-06
-    ub: 0.01
-    index: 1
-  - ground_truth: 2.356156637293247e-05
-    lb: 1.0e-06
-    ub: 0.01
-    index: 2
-  - ground_truth: 0.00019778481012658228
-    lb: 1.0e-06
-    ub: 0.01
-    index: 3
-  - ground_truth: 2.126483222047378e-05
-    lb: 1.0e-06
-    ub: 0.01
-    index: 4
-  - ground_truth: 1.6463073326528597e-05
-    lb: 1.0e-06
-    ub: 0.01
-    index: 5
-  - ground_truth: 2.569637167231987e-05
-    lb: 1.0e-06
-    ub: 0.01
-    index: 6
-migration:
-  matrices:
-  - - [0, 2, 3]
-    - [2, 0, 4]
-    - [3, 4, 0]
-  - - [0, 1, 0]
-    - [1, 0, 0]
-    - [0, 0, 0]
-  - - [0, 0, 0]
-    - [0, 0, 0]
-    - [0, 0, 0]
-  - - [0, 0, 0]
-    - [0, 0, 0]
-    - [0, 0, 0]
-  parameters:
-  - ground_truth: 0.000275
-    lb: 1.0e-06
-    ub: 0.01
-    index: 1
-  - ground_truth: 0.000059
-    lb: 1.0e-06
-    ub: 0.01
-    index: 2
-  - ground_truth: 0.000027
-    lb: 1.0e-06
-    ub: 0.01
-    index: 3
-  - ground_truth: 0.000238
-    lb: 1.0e-06
-    ub: 0.01
-    index: 4
+  - {"ground_truth": 2.9943705833033898e-05, "lb": 1e-06, "ub": 0.01, "index": 1}
+  - {"ground_truth": 2.356156637293247e-05, "lb": 1e-06, "ub": 0.01, "index": 2}
+  - {"ground_truth": 0.00019778481012658228, "lb": 1e-06, "ub": 0.01, "index": 3}
+  - {"ground_truth": 2.126483222047378e-05, "lb": 1e-06, "ub": 0.01, "index": 4}
+  - {"ground_truth": 1.6463073326528597e-05, "lb": 1e-06, "ub": 0.01, "index": 5}
+  - {"ground_truth": 2.569637167231987e-05, "lb": 1e-06, "ub": 0.01, "index": 6}
 growth:
-  vectors:
-  - [3, 1, 2]
-  - [0, 0, 0]
-  - [0, 0, 0]
-  - [0, 0, 0]
+  entries:
+  - {"epoch": 0, "deme": 0, "rate": {"param": 3}}
+  - {"epoch": 0, "deme": 1, "rate": {"param": 1}}
+  - {"epoch": 0, "deme": 2, "rate": {"param": 2}}
   parameters:
-  - ground_truth: 0.002401
-    lb: 0.0001
-    ub: 0.05
-    index: 1
-  - ground_truth: 0.003391
-    lb: 0.0001
-    ub: 0.05
-    index: 2
-  - ground_truth: 0.000943
-    lb: 0.0001
-    ub: 0.05
-    index: 3
-# Notice how the lower/upper bounds for these epochs partition the time axis. This is important
-# to avoid a solution where an older epoch gets a time earlier than a newer epoch.
+  - {"ground_truth": 0.002401, "lb": 0.0001, "ub": 0.05, "index": 1}
+  - {"ground_truth": 0.003391, "lb": 0.0001, "ub": 0.05, "index": 2}
+  - {"ground_truth": 0.000943, "lb": 0.0001, "ub": 0.05, "index": 3}
+migration:
+  entries:
+  - {"epoch": 0, "source": 0, "dest": 1, "rate": {"param": 2}}
+  - {"epoch": 0, "source": 0, "dest": 2, "rate": {"param": 3}}
+  - {"epoch": 0, "source": 1, "dest": 0, "rate": {"param": 2}}
+  - {"epoch": 0, "source": 1, "dest": 2, "rate": {"param": 4}}
+  - {"epoch": 0, "source": 2, "dest": 0, "rate": {"param": 3}}
+  - {"epoch": 0, "source": 2, "dest": 1, "rate": {"param": 4}}
+  - {"epoch": 1, "source": 0, "dest": 1, "rate": {"param": 1}}
+  - {"epoch": 1, "source": 1, "dest": 0, "rate": {"param": 1}}
+  parameters:
+  - {"ground_truth": 0.000275, "lb": 1e-06, "ub": 0.01, "index": 1}
+  - {"ground_truth": 5.9e-05, "lb": 1e-06, "ub": 0.01, "index": 2}
+  - {"ground_truth": 2.7e-05, "lb": 1e-06, "ub": 0.01, "index": 3}
+  - {"ground_truth": 0.000238, "lb": 1e-06, "ub": 0.01, "index": 4}
 epochTimeSplit:
-- ground_truth: 848.0
-  lb: 100.0
-  ub: 1200.0
-  index: 1
-- ground_truth: 5600.0
-  lb: 1200.0
-  ub: 7200.0
-  index: 2
-- ground_truth: 8800.0
-  lb: 7200.0
-  ub: 25000.0
-  index: 3
+- {"ground_truth": 848.0, "lb": 100.0, "ub": 1200.0, "index": 1}
+- {"ground_truth": 5600.0, "lb": 1200.0, "ub": 7200.0, "index": 2}
+- {"ground_truth": 8800.0, "lb": 7200.0, "ub": 25000.0, "index": 3}
 populationConversion:
 - [0, 1, 1]
 - [0, 0, 0]

--- a/examples/ooa_2t12.yaml
+++ b/examples/ooa_2t12.yaml
@@ -1,128 +1,52 @@
-# stdpopsim model OutOfAfrica_2T12, according to which:
-# "Model parameters are taken from Fig. S5 in Fu et al. (2013)"
-
-# Diploid individuals.
 ploidy: 2
-
-# Informational only: the names of population0 and population1, respectively.
+pop_count: 2
 pop_names:
 - AFR
 - EUR
-
-# The coalescence rate parameterization.
 coalescence:
-  # Each vector corresponds to an epoch, and we must have exactly one vector per epoch. Here
-  # we have 5 epochs and 2 demes (populations).
-  # Parameters are indexed 1-based.
-  vectors:
-  - [3, 6]  # Parameter 3 defines the coalescent rate of population0, and param 6 similarly is for population1, in epoch0
-  - [2, 5]
-  - [2, 4]
-  - [2, 0]  # Here, in epoch3, there is no coalescent rate parameter for population1. This is because that population is inactive (not yet created)
-  - [1, 0]
+  entries:
+  - {"epoch": 0, "deme": 0, "rate": {"param": 3}}
+  - {"epoch": 0, "deme": 1, "rate": {"param": 6}}
+  - {"epoch": 1, "deme": 0, "rate": {"param": 2}}
+  - {"epoch": 1, "deme": 1, "rate": {"param": 5}}
+  - {"epoch": 2, "deme": 0, "rate": {"param": 2}}
+  - {"epoch": 2, "deme": 1, "rate": {"param": 4}}
+  - {"epoch": 3, "deme": 0, "rate": {"param": 2}}
+  - {"epoch": 4, "deme": 0, "rate": {"param": 1}}
   parameters:
-    # The ground-truth is used for simulation and for comparing results.
-  - ground_truth: 6.839945280437756e-05
-    # The lower and upper bound are to restrict the search space when solving maximum likelihood.
-    lb: 1.0e-07
-    ub: 0.01
-    # The index here is how we can refer to this parameter in the coalescence vectors. If we put a "1" in the coalescence
-    # vectors above, we are referring to this parameter.
-    index: 1
-  - ground_truth: 3.45447008428907e-05
-    lb: 1.0e-07
-    ub: 0.01
-    index: 2
-  - ground_truth: 1.1570737191765288e-06
-    lb: 1.0e-07
-    ub: 0.01
-    index: 3
-  - ground_truth: 0.00026867275658248256
-    lb: 1.0e-07
-    ub: 0.01
-    index: 4
-  - ground_truth: 5.388388380070718e-05
-    lb: 1.0e-07
-    ub: 0.01
-    index: 5
-  - ground_truth: 9.971355417745619e-07
-    lb: 1.0e-07
-    ub: 0.01
-    index: 6
-# The migration rate parameterization.
-migration:
-  # Since migration rate is between a pair of populations, we have a single matrix per epoch instead of just a vector.
-  matrices:
-  # This first matrix is [ [0, 2], [2, 0] ]. The "2" values refer to the parameter with "index: 2" below. Parameters are
-  # scoped only within their particular parameterization, so "2" under "migration:" is different from "2" under "coalescence:".
-  - - [0, 2]
-    - [2, 0] # The 0s on the diagonal are because migration between a population and itself does not make sense.
-  - - [0, 2]
-    - [2, 0]
-  - - [0, 1]
-    - [1, 0]
-  - - [0, 0] # These last two epochs have no migration at all.
-    - [0, 0]
-  - - [0, 0]
-    - [0, 0]
-  parameters:
-  - ground_truth: 0.00015
-    lb: 1.0e-05
-    ub: 0.01
-    index: 1
-  - ground_truth: 2.5e-05
-    lb: 1.0e-05
-    ub: 0.01
-    index: 2
-# Growth rate parameterization for populations.
+  - {"ground_truth": 6.839945280437756e-05, "lb": 1e-07, "ub": 0.01, "index": 1}
+  - {"ground_truth": 3.45447008428907e-05, "lb": 1e-07, "ub": 0.01, "index": 2}
+  - {"ground_truth": 1.1570737191765288e-06, "lb": 1e-07, "ub": 0.01, "index": 3}
+  - {"ground_truth": 0.00026867275658248256, "lb": 1e-07, "ub": 0.01, "index": 4}
+  - {"ground_truth": 5.388388380070718e-05, "lb": 1e-07, "ub": 0.01, "index": 5}
+  - {"ground_truth": 9.971355417745619e-07, "lb": 1e-07, "ub": 0.01, "index": 6}
 growth:
-  vectors:
-  - [1, 3]  # Epoch0: Both population0 and population1 are growing
-  - [0, 2]  # Epoch1: Only population1 is growing
-  - [0, 0]  # Epoch2: No growth
-  - [0, 0]  # Epoch3: No growth
-  - [0, 0]  # Epoch4: No growth
+  entries:
+  - {"epoch": 0, "deme": 0, "rate": {"param": 1}}
+  - {"epoch": 0, "deme": 1, "rate": {"param": 3}}
+  - {"epoch": 1, "deme": 1, "rate": {"param": 2}}
   parameters:
-  - ground_truth: 0.0166
-    lb: 0.001
-    ub: 0.05
-    index: 1
-  - ground_truth: 0.0030700000000000002
-    lb: 0.001
-    ub: 0.05
-    index: 2
-  - ground_truth: 0.0195
-    lb: 0.001
-    ub: 0.05
-    index: 3
-# The parameters for the transition time between each epoch. There are 5 epochs, so we need 4 of
-# these parameters (for each "in between")
+  - {"ground_truth": 0.0166, "lb": 0.001, "ub": 0.05, "index": 1}
+  - {"ground_truth": 0.0030700000000000002, "lb": 0.001, "ub": 0.05, "index": 2}
+  - {"ground_truth": 0.0195, "lb": 0.001, "ub": 0.05, "index": 3}
+migration:
+  entries:
+  - {"epoch": 0, "source": 0, "dest": 1, "rate": {"param": 2}}
+  - {"epoch": 0, "source": 1, "dest": 0, "rate": {"param": 2}}
+  - {"epoch": 1, "source": 0, "dest": 1, "rate": {"param": 2}}
+  - {"epoch": 1, "source": 1, "dest": 0, "rate": {"param": 2}}
+  - {"epoch": 2, "source": 0, "dest": 1, "rate": {"param": 1}}
+  - {"epoch": 2, "source": 1, "dest": 0, "rate": {"param": 1}}
+  parameters:
+  - {"ground_truth": 0.00015, "lb": 1e-05, "ub": 0.01, "index": 1}
+  - {"ground_truth": 2.5e-05, "lb": 1e-05, "ub": 0.01, "index": 2}
 epochTimeSplit:
-# Split between epoch0 -> epoch1
-- ground_truth: 204.6
-  lb: 100.0
-  ub: 562.0
-  index: 1
-# Split between epoch1 -> epoch2
-- ground_truth: 920.0
-  lb: 562.0
-  ub: 1480.0
-  index: 2
-# Split between epoch2 -> epoch3
-- ground_truth: 2040.0
-  lb: 1480.0
-  ub: 3980.0
-  index: 3
-# Split between epoch3 -> epoch4
-- ground_truth: 5920.0
-  lb: 3980.0
-  ub: 7910.0
-  index: 4
-# How the populations map to each other in between epochs. When the position and the number in it match, there
-# is no splitting of the population. This is viewed backwards in time as a merge of the populations, so if we
-# have v[i] = j, then backwards in time population i merges into population j in between the relevant epochs.
+- {"ground_truth": 204.6, "lb": 100.0, "ub": 562.0, "index": 1}
+- {"ground_truth": 920.0, "lb": 562.0, "ub": 1480.0, "index": 2}
+- {"ground_truth": 2040.0, "lb": 1480.0, "ub": 3980.0, "index": 3}
+- {"ground_truth": 5920.0, "lb": 3980.0, "ub": 7910.0, "index": 4}
 populationConversion:
-- [0, 1]  # epoch0 -> epoch1: v[0] == 0 and v[1] == 1, so there are no splits
-- [0, 1]  # epoch1 -> epoch2: v[0] == 0 and v[1] == 1, so there are no splits
-- [0, 0]  # epoch2 -> epoch3: v[0] == 0, but v[1] == 0, so here we have population1 splitting off from population0 at the start of epoch2 / end of epoch3
-- [0, 0]  # epoch3 -> epoch4: no change from the previous scenario, so there are no new splits
+- [0, 1]
+- [0, 1]
+- [0, 0]
+- [0, 0]

--- a/examples/ooa_2t12.yaml
+++ b/examples/ooa_2t12.yaml
@@ -5,14 +5,14 @@ pop_names:
 - EUR
 coalescence:
   entries:
-  - {"epoch": 0, "deme": 0, "rate": {"param": 3}}
-  - {"epoch": 0, "deme": 1, "rate": {"param": 6}}
-  - {"epoch": 1, "deme": 0, "rate": {"param": 2}}
-  - {"epoch": 1, "deme": 1, "rate": {"param": 5}}
-  - {"epoch": 2, "deme": 0, "rate": {"param": 2}}
-  - {"epoch": 2, "deme": 1, "rate": {"param": 4}}
-  - {"epoch": 3, "deme": 0, "rate": {"param": 2}}
-  - {"epoch": 4, "deme": 0, "rate": {"param": 1}}
+  - {"epoch": 0, "deme": "AFR", "rate": {"param": 3}}
+  - {"epoch": 0, "deme": "EUR", "rate": {"param": 6}}
+  - {"epoch": 1, "deme": "AFR", "rate": {"param": 2}}
+  - {"epoch": 1, "deme": "EUR", "rate": {"param": 5}}
+  - {"epoch": 2, "deme": "AFR", "rate": {"param": 2}}
+  - {"epoch": 2, "deme": "EUR", "rate": {"param": 4}}
+  - {"epoch": 3, "deme": "AFR", "rate": {"param": 2}}
+  - {"epoch": 4, "deme": "AFR", "rate": {"param": 1}}
   parameters:
   - {"ground_truth": 6.839945280437756e-05, "lb": 1e-07, "ub": 0.01, "index": 1}
   - {"ground_truth": 3.45447008428907e-05, "lb": 1e-07, "ub": 0.01, "index": 2}
@@ -22,21 +22,21 @@ coalescence:
   - {"ground_truth": 9.971355417745619e-07, "lb": 1e-07, "ub": 0.01, "index": 6}
 growth:
   entries:
-  - {"epoch": 0, "deme": 0, "rate": {"param": 1}}
-  - {"epoch": 0, "deme": 1, "rate": {"param": 3}}
-  - {"epoch": 1, "deme": 1, "rate": {"param": 2}}
+  - {"epoch": 0, "deme": "AFR", "rate": {"param": 1}}
+  - {"epoch": 0, "deme": "EUR", "rate": {"param": 3}}
+  - {"epoch": 1, "deme": "EUR", "rate": {"param": 2}}
   parameters:
   - {"ground_truth": 0.0166, "lb": 0.001, "ub": 0.05, "index": 1}
   - {"ground_truth": 0.0030700000000000002, "lb": 0.001, "ub": 0.05, "index": 2}
   - {"ground_truth": 0.0195, "lb": 0.001, "ub": 0.05, "index": 3}
 migration:
   entries:
-  - {"epoch": 0, "source": 0, "dest": 1, "rate": {"param": 2}}
-  - {"epoch": 0, "source": 1, "dest": 0, "rate": {"param": 2}}
-  - {"epoch": 1, "source": 0, "dest": 1, "rate": {"param": 2}}
-  - {"epoch": 1, "source": 1, "dest": 0, "rate": {"param": 2}}
-  - {"epoch": 2, "source": 0, "dest": 1, "rate": {"param": 1}}
-  - {"epoch": 2, "source": 1, "dest": 0, "rate": {"param": 1}}
+  - {"epoch": 0, "source": "AFR", "dest": "EUR", "rate": {"param": 2}}
+  - {"epoch": 0, "source": "EUR", "dest": "AFR", "rate": {"param": 2}}
+  - {"epoch": 1, "source": "AFR", "dest": "EUR", "rate": {"param": 2}}
+  - {"epoch": 1, "source": "EUR", "dest": "AFR", "rate": {"param": 2}}
+  - {"epoch": 2, "source": "AFR", "dest": "EUR", "rate": {"param": 1}}
+  - {"epoch": 2, "source": "EUR", "dest": "AFR", "rate": {"param": 1}}
   parameters:
   - {"ground_truth": 0.00015, "lb": 1e-05, "ub": 0.01, "index": 1}
   - {"ground_truth": 2.5e-05, "lb": 1e-05, "ub": 0.01, "index": 2}

--- a/examples/ooa_2t12ExtendedNeanderthalAdmixture.yaml
+++ b/examples/ooa_2t12ExtendedNeanderthalAdmixture.yaml
@@ -1,124 +1,61 @@
-# stdpopsim model OutOfAfrica_2T12+ExtendedNeanderthalAdmixture, OutOfAfrica_2T12 is according to which:
-# "Model parameters are taken from Fig. S5 in Fu et al. (2013)"
-# ExtendedNeanderthalAdmixture is added in based on OutOfAfricaExtendedNeandertalAdmixturePulse_3I21 from
-# paper Iasi et al. (2021) with some changes to increase the extended pulse a little bit.
 ploidy: 2
+pop_count: 3
 pop_names:
 - AFR
 - EUR
-- NEAN # Additional Neanderthal deme
+- NEAN
 coalescence:
-  vectors:
-  - [3, 6, 7]
-  - [2, 5, 7]
-  - [2, 4, 7]
-  - [2, 0, 7]
-  - [1, 0, 7]
-  - [1, 0, 0]
+  entries:
+  - {"epoch": 0, "deme": 0, "rate": {"param": 3}}
+  - {"epoch": 0, "deme": 1, "rate": {"param": 6}}
+  - {"epoch": 0, "deme": 2, "rate": {"param": 7}}
+  - {"epoch": 1, "deme": 0, "rate": {"param": 2}}
+  - {"epoch": 1, "deme": 1, "rate": {"param": 5}}
+  - {"epoch": 1, "deme": 2, "rate": {"param": 7}}
+  - {"epoch": 2, "deme": 0, "rate": {"param": 2}}
+  - {"epoch": 2, "deme": 1, "rate": {"param": 4}}
+  - {"epoch": 2, "deme": 2, "rate": {"param": 7}}
+  - {"epoch": 3, "deme": 0, "rate": {"param": 2}}
+  - {"epoch": 3, "deme": 2, "rate": {"param": 7}}
+  - {"epoch": 4, "deme": 0, "rate": {"param": 1}}
+  - {"epoch": 4, "deme": 2, "rate": {"param": 7}}
+  - {"epoch": 5, "deme": 0, "rate": {"param": 1}}
   parameters:
-  - ground_truth: 6.839945280437756e-05
-    lb: 1e-07
-    ub: 0.01
-    index: 1
-  - ground_truth: 3.45447008428907e-05
-    lb: 1e-07
-    ub: 0.01
-    index: 2
-  - ground_truth: 1.1570737191765288e-06
-    lb: 1e-07
-    ub: 0.01
-    index: 3
-  - ground_truth: 0.00026867275658248256
-    lb: 1e-07
-    ub: 0.01
-    index: 4
-  - ground_truth: 5.388388380070718e-05
-    lb: 1e-07
-    ub: 0.01
-    index: 5
-  - ground_truth: 9.971355417745619e-07
-    lb: 1e-07
-    ub: 0.01
-    index: 6
-  - ground_truth: 5e-05 # Parameter 7; using the Ne = 10000 from OutOfAfricaExtendedNeandertalAdmixturePulse_3I21
-    lb: 1e-07
-    ub: 0.01
-    index: 7
-migration:
-  matrices:
-  - - [0, 2, 0]
-    - [2, 0, 0]
-    - [0, 0, 0]
-  - - [0, 2, 0]
-    - [2, 0, 0]
-    - [0, 0, 0]
-  - - [0, 1, 0] # This becomes the epoch with NEAN-> EUR
-    - [1, 0, 3]
-    - [0, 0, 0]
-  - - [0, 0, 0]
-    - [0, 0, 0]
-    - [0, 0, 0]
-  - - [0, 0, 0] # Add a new epoch to indicate the Human-Neanderthal split
-    - [0, 0, 0]
-    - [0, 0, 0]
-  - - [0, 0, 0]
-    - [0, 0, 0]
-    - [0, 0, 0]
-  parameters:
-  - ground_truth: 0.00015
-    lb: 1e-05
-    ub: 0.01
-    index: 1
-  - ground_truth: 2.5e-05
-    lb: 1e-05
-    ub: 0.01
-    index: 2
-  - ground_truth: 2.678e-5 # Add NEAN -> EUR migration, rate based on 0.03/1120 generations, a simplified extended pulse
-    lb: 1e-05
-    ub: 0.01
-    index: 3
+  - {"ground_truth": 6.839945280437756e-05, "lb": 1e-07, "ub": 0.01, "index": 1}
+  - {"ground_truth": 3.45447008428907e-05, "lb": 1e-07, "ub": 0.01, "index": 2}
+  - {"ground_truth": 1.1570737191765288e-06, "lb": 1e-07, "ub": 0.01, "index": 3}
+  - {"ground_truth": 0.00026867275658248256, "lb": 1e-07, "ub": 0.01, "index": 4}
+  - {"ground_truth": 5.388388380070718e-05, "lb": 1e-07, "ub": 0.01, "index": 5}
+  - {"ground_truth": 9.971355417745619e-07, "lb": 1e-07, "ub": 0.01, "index": 6}
+  - {"ground_truth": 5e-05, "lb": 1e-07, "ub": 0.01, "index": 7}
 growth:
-  vectors:
-  - [1, 3, 0]
-  - [0, 2, 0]
-  - [0, 0, 0] # This become the epoch with NEAN-> EUR
-  - [0, 0, 0]
-  - [0, 0, 0]
-  - [0, 0, 0]
+  entries:
+  - {"epoch": 0, "deme": 0, "rate": {"param": 1}}
+  - {"epoch": 0, "deme": 1, "rate": {"param": 3}}
+  - {"epoch": 1, "deme": 1, "rate": {"param": 2}}
   parameters:
-  - ground_truth: 0.0166
-    lb: 0.001
-    ub: 0.05
-    index: 1
-  - ground_truth: 0.0030700000000000002
-    lb: 0.001
-    ub: 0.05
-    index: 2
-  - ground_truth: 0.0195
-    lb: 0.001
-    ub: 0.05
-    index: 3
-epochTimeSplit: # Below are simplified to try to only increase the epoch time by 1.
-- ground_truth: 204.6
-  lb: 100.0
-  ub: 562.0
-  index: 1
-- ground_truth: 920.0 # Assume NEAN-> EUR continues till this time
-  lb: 562.0
-  ub: 1480.0
-  index: 2
-- ground_truth: 2040.0 # Assume NEAN-> EUR also happens at this time
-  lb: 1480.0
-  ub: 3980.0
-  index: 3
-- ground_truth: 5920.0
-  lb: 3980.0
-  ub: 7910.0
-  index: 4
-- ground_truth: 10000.0 # Human-Neanderthal split
-  lb: 9000.0
-  ub: 12000.0
-  index: 5
+  - {"ground_truth": 0.0166, "lb": 0.001, "ub": 0.05, "index": 1}
+  - {"ground_truth": 0.0030700000000000002, "lb": 0.001, "ub": 0.05, "index": 2}
+  - {"ground_truth": 0.0195, "lb": 0.001, "ub": 0.05, "index": 3}
+migration:
+  entries:
+  - {"epoch": 0, "source": 0, "dest": 1, "rate": {"param": 2}}
+  - {"epoch": 0, "source": 1, "dest": 0, "rate": {"param": 2}}
+  - {"epoch": 1, "source": 0, "dest": 1, "rate": {"param": 2}}
+  - {"epoch": 1, "source": 1, "dest": 0, "rate": {"param": 2}}
+  - {"epoch": 2, "source": 0, "dest": 1, "rate": {"param": 1}}
+  - {"epoch": 2, "source": 1, "dest": 0, "rate": {"param": 1}}
+  - {"epoch": 2, "source": 1, "dest": 2, "rate": {"param": 3}}
+  parameters:
+  - {"ground_truth": 0.00015, "lb": 1e-05, "ub": 0.01, "index": 1}
+  - {"ground_truth": 2.5e-05, "lb": 1e-05, "ub": 0.01, "index": 2}
+  - {"ground_truth": 2.678e-05, "lb": 1e-05, "ub": 0.01, "index": 3}
+epochTimeSplit:
+- {"ground_truth": 204.6, "lb": 100.0, "ub": 562.0, "index": 1}
+- {"ground_truth": 920.0, "lb": 562.0, "ub": 1480.0, "index": 2}
+- {"ground_truth": 2040.0, "lb": 1480.0, "ub": 3980.0, "index": 3}
+- {"ground_truth": 5920.0, "lb": 3980.0, "ub": 7910.0, "index": 4}
+- {"ground_truth": 10000.0, "lb": 9000.0, "ub": 12000.0, "index": 5}
 populationConversion:
 - [0, 1, 2]
 - [0, 1, 2]

--- a/examples/ooa_3g09.fixed.yaml
+++ b/examples/ooa_3g09.fixed.yaml
@@ -1,99 +1,50 @@
-# OutOfAfrica_3G09 from stdpopsim, converted from the Demes model that was exported
-# from stdpopsim. From Gutenkunst et al., 2009
-# Variant: the epoch times are essentially fixed (tightly bounded).
 ploidy: 2
+pop_count: 3
 pop_names:
 - YRI
 - CEU
 - CHB
 coalescence:
-  vectors:
-  - [2, 4, 5]
-  - [2, 3, 0]
-  - [2, 0, 0]
-  - [1, 0, 0]
+  entries:
+  - {"epoch": 0, "deme": 0, "rate": {"param": 2}}
+  - {"epoch": 0, "deme": 1, "rate": {"param": 4}}
+  - {"epoch": 0, "deme": 2, "rate": {"param": 5}}
+  - {"epoch": 1, "deme": 0, "rate": {"param": 2}}
+  - {"epoch": 1, "deme": 1, "rate": {"param": 3}}
+  - {"epoch": 2, "deme": 0, "rate": {"param": 2}}
+  - {"epoch": 3, "deme": 0, "rate": {"param": 1}}
   parameters:
-  - ground_truth: 6.84931506849315e-05
-    lb: 1.0e-06
-    ub: 0.01
-    index: 1
-  - ground_truth: 4.065040650406504e-05
-    lb: 1.0e-06
-    ub: 0.01
-    index: 2
-  - ground_truth: 0.0002380952380952381
-    lb: 1.0e-06
-    ub: 0.01
-    index: 3
-  - ground_truth: 1.682066345910231e-05
-    lb: 1.0e-06
-    ub: 0.01
-    index: 4
-  - ground_truth: 9.243796257772543e-06
-    lb: 1.0e-06
-    ub: 0.01
-    index: 5
-migration:
-  matrices:
-  - - [0, 2, 3]
-    - [2, 0, 4]
-    - [3, 4, 0]
-  - - [0, 1, 0]
-    - [1, 0, 0]
-    - [0, 0, 0]
-  - - [0, 0, 0]
-    - [0, 0, 0]
-    - [0, 0, 0]
-  - - [0, 0, 0]
-    - [0, 0, 0]
-    - [0, 0, 0]
-  parameters:
-  - ground_truth: 0.00025
-    lb: 1.0e-05
-    ub: 0.01
-    index: 1
-  - ground_truth: 3.0e-05
-    lb: 1.0e-05
-    ub: 0.01
-    index: 2
-  - ground_truth: 1.9e-05
-    lb: 1.0e-05
-    ub: 0.01
-    index: 3
-  - ground_truth: 9.6e-05
-    lb: 1.0e-05
-    ub: 0.01
-    index: 4
+  - {"ground_truth": 6.84931506849315e-05, "lb": 1e-06, "ub": 0.01, "index": 1}
+  - {"ground_truth": 4.065040650406504e-05, "lb": 1e-06, "ub": 0.01, "index": 2}
+  - {"ground_truth": 0.0002380952380952381, "lb": 1e-06, "ub": 0.01, "index": 3}
+  - {"ground_truth": 1.682066345910231e-05, "lb": 1e-06, "ub": 0.01, "index": 4}
+  - {"ground_truth": 9.243796257772543e-06, "lb": 1e-06, "ub": 0.01, "index": 5}
 growth:
-  vectors:
-  - [0, 1, 2]
-  - [0, 0, 0]
-  - [0, 0, 0]
-  - [0, 0, 0]
+  entries:
+  - {"epoch": 0, "deme": 1, "rate": {"param": 1}}
+  - {"epoch": 0, "deme": 2, "rate": {"param": 2}}
   parameters:
-  - ground_truth: 0.004
-    lb: 0.001
-    ub: 0.05
-    index: 1
-  - ground_truth: 0.0055
-    lb: 0.001
-    ub: 0.05
-    index: 2
-# Notice how the lower/upper bounds for these epochs partition the time axis. This is important
-# to avoid a solution where an older epoch gets a time earlier than a newer epoch.
+  - {"ground_truth": 0.004, "lb": 0.001, "ub": 0.05, "index": 1}
+  - {"ground_truth": 0.0055, "lb": 0.001, "ub": 0.05, "index": 2}
+migration:
+  entries:
+  - {"epoch": 0, "source": 0, "dest": 1, "rate": {"param": 2}}
+  - {"epoch": 0, "source": 0, "dest": 2, "rate": {"param": 3}}
+  - {"epoch": 0, "source": 1, "dest": 0, "rate": {"param": 2}}
+  - {"epoch": 0, "source": 1, "dest": 2, "rate": {"param": 4}}
+  - {"epoch": 0, "source": 2, "dest": 0, "rate": {"param": 3}}
+  - {"epoch": 0, "source": 2, "dest": 1, "rate": {"param": 4}}
+  - {"epoch": 1, "source": 0, "dest": 1, "rate": {"param": 1}}
+  - {"epoch": 1, "source": 1, "dest": 0, "rate": {"param": 1}}
+  parameters:
+  - {"ground_truth": 0.00025, "lb": 1e-05, "ub": 0.01, "index": 1}
+  - {"ground_truth": 3e-05, "lb": 1e-05, "ub": 0.01, "index": 2}
+  - {"ground_truth": 1.9e-05, "lb": 1e-05, "ub": 0.01, "index": 3}
+  - {"ground_truth": 9.6e-05, "lb": 1e-05, "ub": 0.01, "index": 4}
 epochTimeSplit:
-- ground_truth: 848.0
-  lb: 847.0
-  ub: 849.0
-  index: 1
-- ground_truth: 5600.0
-  lb: 5599.0
-  ub: 5601.0
-  index: 2
-- ground_truth: 8800.0
-  lb: 8799.0
-  ub: 8801.0
-  index: 3
+- {"ground_truth": 848.0, "lb": 847.0, "ub": 849.0, "index": 1}
+- {"ground_truth": 5600.0, "lb": 5599.0, "ub": 5601.0, "index": 2}
+- {"ground_truth": 8800.0, "lb": 8799.0, "ub": 8801.0, "index": 3}
 populationConversion:
 - [0, 1, 1]
 - [0, 0, 0]

--- a/examples/ooa_3g09.yaml
+++ b/examples/ooa_3g09.yaml
@@ -6,13 +6,13 @@ pop_names:
 - CHB
 coalescence:
   entries:
-  - {"epoch": 0, "deme": 0, "rate": {"param": 2}}
-  - {"epoch": 0, "deme": 1, "rate": {"param": 4}}
-  - {"epoch": 0, "deme": 2, "rate": {"param": 5}}
-  - {"epoch": 1, "deme": 0, "rate": {"param": 2}}
-  - {"epoch": 1, "deme": 1, "rate": {"param": 3}}
-  - {"epoch": 2, "deme": 0, "rate": {"param": 2}}
-  - {"epoch": 3, "deme": 0, "rate": {"param": 1}}
+  - {"epoch": 0, "deme": "YRI", "rate": {"param": 2}}
+  - {"epoch": 0, "deme": "CEU", "rate": {"param": 4}}
+  - {"epoch": 0, "deme": "CHB", "rate": {"param": 5}}
+  - {"epoch": 1, "deme": "YRI", "rate": {"param": 2}}
+  - {"epoch": 1, "deme": "CEU", "rate": {"param": 3}}
+  - {"epoch": 2, "deme": "YRI", "rate": {"param": 2}}
+  - {"epoch": 3, "deme": "YRI", "rate": {"param": 1}}
   parameters:
   - {"ground_truth": 6.84931506849315e-05, "lb": 1e-06, "ub": 0.01, "index": 1}
   - {"ground_truth": 4.065040650406504e-05, "lb": 1e-06, "ub": 0.01, "index": 2}
@@ -21,21 +21,21 @@ coalescence:
   - {"ground_truth": 9.243796257772543e-06, "lb": 1e-06, "ub": 0.01, "index": 5}
 growth:
   entries:
-  - {"epoch": 0, "deme": 1, "rate": {"param": 1}}
-  - {"epoch": 0, "deme": 2, "rate": {"param": 2}}
+  - {"epoch": 0, "deme": "CEU", "rate": {"param": 1}}
+  - {"epoch": 0, "deme": "CHB", "rate": {"param": 2}}
   parameters:
   - {"ground_truth": 0.004, "lb": 0.001, "ub": 0.05, "index": 1}
   - {"ground_truth": 0.0055, "lb": 0.001, "ub": 0.05, "index": 2}
 migration:
   entries:
-  - {"epoch": 0, "source": 0, "dest": 1, "rate": {"param": 2}}
-  - {"epoch": 0, "source": 0, "dest": 2, "rate": {"param": 3}}
-  - {"epoch": 0, "source": 1, "dest": 0, "rate": {"param": 2}}
-  - {"epoch": 0, "source": 1, "dest": 2, "rate": {"param": 4}}
-  - {"epoch": 0, "source": 2, "dest": 0, "rate": {"param": 3}}
-  - {"epoch": 0, "source": 2, "dest": 1, "rate": {"param": 4}}
-  - {"epoch": 1, "source": 0, "dest": 1, "rate": {"param": 1}}
-  - {"epoch": 1, "source": 1, "dest": 0, "rate": {"param": 1}}
+  - {"epoch": 0, "source": "YRI", "dest": "CEU", "rate": {"param": 2}}
+  - {"epoch": 0, "source": "YRI", "dest": "CHB", "rate": {"param": 3}}
+  - {"epoch": 0, "source": "CEU", "dest": "YRI", "rate": {"param": 2}}
+  - {"epoch": 0, "source": "CEU", "dest": "CHB", "rate": {"param": 4}}
+  - {"epoch": 0, "source": "CHB", "dest": "YRI", "rate": {"param": 3}}
+  - {"epoch": 0, "source": "CHB", "dest": "CEU", "rate": {"param": 4}}
+  - {"epoch": 1, "source": "YRI", "dest": "CEU", "rate": {"param": 1}}
+  - {"epoch": 1, "source": "CEU", "dest": "YRI", "rate": {"param": 1}}
   parameters:
   - {"ground_truth": 0.00025, "lb": 1e-05, "ub": 0.01, "index": 1}
   - {"ground_truth": 3e-05, "lb": 1e-05, "ub": 0.01, "index": 2}

--- a/examples/ooa_3g09.yaml
+++ b/examples/ooa_3g09.yaml
@@ -1,98 +1,50 @@
-# OutOfAfrica_3G09 from stdpopsim, converted from the Demes model that was exported
-# from stdpopsim. From Gutenkunst et al., 2009
 ploidy: 2
+pop_count: 3
 pop_names:
 - YRI
 - CEU
 - CHB
 coalescence:
-  vectors:
-  - [2, 4, 5]
-  - [2, 3, 0]
-  - [2, 0, 0]
-  - [1, 0, 0]
+  entries:
+  - {"epoch": 0, "deme": 0, "rate": {"param": 2}}
+  - {"epoch": 0, "deme": 1, "rate": {"param": 4}}
+  - {"epoch": 0, "deme": 2, "rate": {"param": 5}}
+  - {"epoch": 1, "deme": 0, "rate": {"param": 2}}
+  - {"epoch": 1, "deme": 1, "rate": {"param": 3}}
+  - {"epoch": 2, "deme": 0, "rate": {"param": 2}}
+  - {"epoch": 3, "deme": 0, "rate": {"param": 1}}
   parameters:
-  - ground_truth: 6.84931506849315e-05
-    lb: 1.0e-06
-    ub: 0.01
-    index: 1
-  - ground_truth: 4.065040650406504e-05
-    lb: 1.0e-06
-    ub: 0.01
-    index: 2
-  - ground_truth: 0.0002380952380952381
-    lb: 1.0e-06
-    ub: 0.01
-    index: 3
-  - ground_truth: 1.682066345910231e-05
-    lb: 1.0e-06
-    ub: 0.01
-    index: 4
-  - ground_truth: 9.243796257772543e-06
-    lb: 1.0e-06
-    ub: 0.01
-    index: 5
-migration:
-  matrices:
-  - - [0, 2, 3]
-    - [2, 0, 4]
-    - [3, 4, 0]
-  - - [0, 1, 0]
-    - [1, 0, 0]
-    - [0, 0, 0]
-  - - [0, 0, 0]
-    - [0, 0, 0]
-    - [0, 0, 0]
-  - - [0, 0, 0]
-    - [0, 0, 0]
-    - [0, 0, 0]
-  parameters:
-  - ground_truth: 0.00025
-    lb: 1.0e-05
-    ub: 0.01
-    index: 1
-  - ground_truth: 3.0e-05
-    lb: 1.0e-05
-    ub: 0.01
-    index: 2
-  - ground_truth: 1.9e-05
-    lb: 1.0e-05
-    ub: 0.01
-    index: 3
-  - ground_truth: 9.6e-05
-    lb: 1.0e-05
-    ub: 0.01
-    index: 4
+  - {"ground_truth": 6.84931506849315e-05, "lb": 1e-06, "ub": 0.01, "index": 1}
+  - {"ground_truth": 4.065040650406504e-05, "lb": 1e-06, "ub": 0.01, "index": 2}
+  - {"ground_truth": 0.0002380952380952381, "lb": 1e-06, "ub": 0.01, "index": 3}
+  - {"ground_truth": 1.682066345910231e-05, "lb": 1e-06, "ub": 0.01, "index": 4}
+  - {"ground_truth": 9.243796257772543e-06, "lb": 1e-06, "ub": 0.01, "index": 5}
 growth:
-  vectors:
-  - [0, 1, 2]
-  - [0, 0, 0]
-  - [0, 0, 0]
-  - [0, 0, 0]
+  entries:
+  - {"epoch": 0, "deme": 1, "rate": {"param": 1}}
+  - {"epoch": 0, "deme": 2, "rate": {"param": 2}}
   parameters:
-  - ground_truth: 0.004
-    lb: 0.001
-    ub: 0.05
-    index: 1
-  - ground_truth: 0.0055
-    lb: 0.001
-    ub: 0.05
-    index: 2
-# Notice how the lower/upper bounds for these epochs partition the time axis. This is important
-# to avoid a solution where an older epoch gets a time earlier than a newer epoch.
+  - {"ground_truth": 0.004, "lb": 0.001, "ub": 0.05, "index": 1}
+  - {"ground_truth": 0.0055, "lb": 0.001, "ub": 0.05, "index": 2}
+migration:
+  entries:
+  - {"epoch": 0, "source": 0, "dest": 1, "rate": {"param": 2}}
+  - {"epoch": 0, "source": 0, "dest": 2, "rate": {"param": 3}}
+  - {"epoch": 0, "source": 1, "dest": 0, "rate": {"param": 2}}
+  - {"epoch": 0, "source": 1, "dest": 2, "rate": {"param": 4}}
+  - {"epoch": 0, "source": 2, "dest": 0, "rate": {"param": 3}}
+  - {"epoch": 0, "source": 2, "dest": 1, "rate": {"param": 4}}
+  - {"epoch": 1, "source": 0, "dest": 1, "rate": {"param": 1}}
+  - {"epoch": 1, "source": 1, "dest": 0, "rate": {"param": 1}}
+  parameters:
+  - {"ground_truth": 0.00025, "lb": 1e-05, "ub": 0.01, "index": 1}
+  - {"ground_truth": 3e-05, "lb": 1e-05, "ub": 0.01, "index": 2}
+  - {"ground_truth": 1.9e-05, "lb": 1e-05, "ub": 0.01, "index": 3}
+  - {"ground_truth": 9.6e-05, "lb": 1e-05, "ub": 0.01, "index": 4}
 epochTimeSplit:
-- ground_truth: 848.0
-  lb: 100.0
-  ub: 1200.0
-  index: 1
-- ground_truth: 5600.0
-  lb: 1200.0
-  ub: 7200.0
-  index: 2
-- ground_truth: 8800.0
-  lb: 7200.0
-  ub: 25000.0
-  index: 3
+- {"ground_truth": 848.0, "lb": 100.0, "ub": 1200.0, "index": 1}
+- {"ground_truth": 5600.0, "lb": 1200.0, "ub": 7200.0, "index": 2}
+- {"ground_truth": 8800.0, "lb": 7200.0, "ub": 25000.0, "index": 3}
 populationConversion:
 - [0, 1, 1]
 - [0, 0, 0]

--- a/examples/ooa_4j17.yaml
+++ b/examples/ooa_4j17.yaml
@@ -1,123 +1,70 @@
-# OutOfAfrica_4J17 from stdpopsim, converted from the Demes model that was exported
-# from stdpopsim. From Jouganous et al. (2017).
 ploidy: 2
+pop_count: 4
 pop_names:
 - YRI
 - CEU
 - CHB
 - JPT
 coalescence:
-  vectors:
-  - [2, 4, 5, 6]
-  - [2, 4, 5, 0]
-  - [2, 3, 0, 0]
-  - [2, 0, 0, 0]
-  - [1, 0, 0, 0]
+  entries:
+  - {"epoch": 0, "deme": 0, "rate": {"param": 2}}
+  - {"epoch": 0, "deme": 1, "rate": {"param": 4}}
+  - {"epoch": 0, "deme": 2, "rate": {"param": 5}}
+  - {"epoch": 0, "deme": 3, "rate": {"param": 6}}
+  - {"epoch": 1, "deme": 0, "rate": {"param": 2}}
+  - {"epoch": 1, "deme": 1, "rate": {"param": 4}}
+  - {"epoch": 1, "deme": 2, "rate": {"param": 5}}
+  - {"epoch": 2, "deme": 0, "rate": {"param": 2}}
+  - {"epoch": 2, "deme": 1, "rate": {"param": 3}}
+  - {"epoch": 3, "deme": 0, "rate": {"param": 2}}
+  - {"epoch": 4, "deme": 0, "rate": {"param": 1}}
   parameters:
-  - ground_truth: 4.4275214734791464e-05
-    lb: 1.0e-06
-    ub: 0.01
-    index: 1
-  - ground_truth: 2.107836937734497e-05
-    lb: 1.0e-06
-    ub: 0.01
-    index: 2
-  - ground_truth: 0.00017661603673613564
-    lb: 1.0e-06
-    ub: 0.01
-    index: 3
-  - ground_truth: 1.5735650172615685e-05
-    lb: 1.0e-06
-    ub: 0.01
-    index: 4
-  - ground_truth: 7.94216846330162e-06
-    lb: 1.0e-06
-    ub: 0.01
-    index: 5
-  - ground_truth: 2.091008632355808e-06
-    lb: 1.0e-06
-    ub: 0.01
-    index: 6
-migration:
-  matrices:
-  - - [0, 2, 3, 0]
-    - [2, 0, 4, 0]
-    - [3, 4, 0, 5]
-    - [0, 0, 5, 0]
-  - - [0, 2, 3, 0]
-    - [2, 0, 4, 0]
-    - [3, 4, 0, 0]
-    - [0, 0, 0, 0]
-  - - [0, 1, 0, 0]
-    - [1, 0, 0, 0]
-    - [0, 0, 0, 0]
-    - [0, 0, 0, 0]
-  - - [0, 0, 0, 0]
-    - [0, 0, 0, 0]
-    - [0, 0, 0, 0]
-    - [0, 0, 0, 0]
-  - - [0, 0, 0, 0]
-    - [0, 0, 0, 0]
-    - [0, 0, 0, 0]
-    - [0, 0, 0, 0]
-  parameters:
-  - ground_truth: 0.000168
-    lb: 1.0e-06
-    ub: 0.01
-    index: 1
-  - ground_truth: 1.14e-05
-    lb: 1.0e-06
-    ub: 0.01
-    index: 2
-  - ground_truth: 5.6e-06
-    lb: 1.0e-06
-    ub: 0.01
-    index: 3
-  - ground_truth: 4.75e-05
-    lb: 1.0e-06
-    ub: 0.01
-    index: 4
-  - ground_truth: 3.3e-05
-    lb: 1.0e-06
-    ub: 0.01
-    index: 5
+  - {"ground_truth": 4.4275214734791464e-05, "lb": 1e-06, "ub": 0.01, "index": 1}
+  - {"ground_truth": 2.107836937734497e-05, "lb": 1e-06, "ub": 0.01, "index": 2}
+  - {"ground_truth": 0.00017661603673613564, "lb": 1e-06, "ub": 0.01, "index": 3}
+  - {"ground_truth": 1.5735650172615685e-05, "lb": 1e-06, "ub": 0.01, "index": 4}
+  - {"ground_truth": 7.94216846330162e-06, "lb": 1e-06, "ub": 0.01, "index": 5}
+  - {"ground_truth": 2.091008632355808e-06, "lb": 1e-06, "ub": 0.01, "index": 6}
 growth:
-  vectors:
-  - [0, 1, 2, 3]
-  - [0, 1, 2, 0]
-  - [0, 0, 0, 0]
-  - [0, 0, 0, 0]
-  - [0, 0, 0, 0]
+  entries:
+  - {"epoch": 0, "deme": 1, "rate": {"param": 1}}
+  - {"epoch": 0, "deme": 2, "rate": {"param": 2}}
+  - {"epoch": 0, "deme": 3, "rate": {"param": 3}}
+  - {"epoch": 1, "deme": 1, "rate": {"param": 1}}
+  - {"epoch": 1, "deme": 2, "rate": {"param": 2}}
   parameters:
-  - ground_truth: 0.0016000000000000003
-    lb: 0.001
-    ub: 0.05
-    index: 1
-  - ground_truth: 0.0026
-    lb: 0.001
-    ub: 0.05
-    index: 2
-  - ground_truth: 0.0129
-    lb: 0.001
-    ub: 0.05
-    index: 3
+  - {"ground_truth": 0.0016000000000000003, "lb": 0.001, "ub": 0.05, "index": 1}
+  - {"ground_truth": 0.0026, "lb": 0.001, "ub": 0.05, "index": 2}
+  - {"ground_truth": 0.0129, "lb": 0.001, "ub": 0.05, "index": 3}
+migration:
+  entries:
+  - {"epoch": 0, "source": 0, "dest": 1, "rate": {"param": 2}}
+  - {"epoch": 0, "source": 0, "dest": 2, "rate": {"param": 3}}
+  - {"epoch": 0, "source": 1, "dest": 0, "rate": {"param": 2}}
+  - {"epoch": 0, "source": 1, "dest": 2, "rate": {"param": 4}}
+  - {"epoch": 0, "source": 2, "dest": 0, "rate": {"param": 3}}
+  - {"epoch": 0, "source": 2, "dest": 1, "rate": {"param": 4}}
+  - {"epoch": 0, "source": 2, "dest": 3, "rate": {"param": 5}}
+  - {"epoch": 0, "source": 3, "dest": 2, "rate": {"param": 5}}
+  - {"epoch": 1, "source": 0, "dest": 1, "rate": {"param": 2}}
+  - {"epoch": 1, "source": 0, "dest": 2, "rate": {"param": 3}}
+  - {"epoch": 1, "source": 1, "dest": 0, "rate": {"param": 2}}
+  - {"epoch": 1, "source": 1, "dest": 2, "rate": {"param": 4}}
+  - {"epoch": 1, "source": 2, "dest": 0, "rate": {"param": 3}}
+  - {"epoch": 1, "source": 2, "dest": 1, "rate": {"param": 4}}
+  - {"epoch": 2, "source": 0, "dest": 1, "rate": {"param": 1}}
+  - {"epoch": 2, "source": 1, "dest": 0, "rate": {"param": 1}}
+  parameters:
+  - {"ground_truth": 0.000168, "lb": 1e-06, "ub": 0.01, "index": 1}
+  - {"ground_truth": 1.14e-05, "lb": 1e-06, "ub": 0.01, "index": 2}
+  - {"ground_truth": 5.6e-06, "lb": 1e-06, "ub": 0.01, "index": 3}
+  - {"ground_truth": 4.75e-05, "lb": 1e-06, "ub": 0.01, "index": 4}
+  - {"ground_truth": 3.3e-05, "lb": 1e-06, "ub": 0.01, "index": 5}
 epochTimeSplit:
-- ground_truth: 310
-  lb: 100.0
-  ub: 948
-  index: 1
-- ground_truth: 1586
-  lb: 948
-  ub: 2844
-  index: 2
-- ground_truth: 4103
-  lb: 2844
-  ub: 8206
-  index: 3
-- ground_truth: 12310
-  lb: 8206
-  ub: 16413
-  index: 4
+- {"ground_truth": 310.0, "lb": 100.0, "ub": 948.0, "index": 1}
+- {"ground_truth": 1586.0, "lb": 948.0, "ub": 2844.0, "index": 2}
+- {"ground_truth": 4103.0, "lb": 2844.0, "ub": 8206.0, "index": 3}
+- {"ground_truth": 12310.0, "lb": 8206.0, "ub": 16413.0, "index": 4}
 populationConversion:
 - [0, 1, 2, 2]
 - [0, 1, 1, 1]

--- a/examples/ooa_4j17.yaml
+++ b/examples/ooa_4j17.yaml
@@ -7,17 +7,17 @@ pop_names:
 - JPT
 coalescence:
   entries:
-  - {"epoch": 0, "deme": 0, "rate": {"param": 2}}
-  - {"epoch": 0, "deme": 1, "rate": {"param": 4}}
-  - {"epoch": 0, "deme": 2, "rate": {"param": 5}}
-  - {"epoch": 0, "deme": 3, "rate": {"param": 6}}
-  - {"epoch": 1, "deme": 0, "rate": {"param": 2}}
-  - {"epoch": 1, "deme": 1, "rate": {"param": 4}}
-  - {"epoch": 1, "deme": 2, "rate": {"param": 5}}
-  - {"epoch": 2, "deme": 0, "rate": {"param": 2}}
-  - {"epoch": 2, "deme": 1, "rate": {"param": 3}}
-  - {"epoch": 3, "deme": 0, "rate": {"param": 2}}
-  - {"epoch": 4, "deme": 0, "rate": {"param": 1}}
+  - {"epoch": 0, "deme": "YRI", "rate": {"param": 2}}
+  - {"epoch": 0, "deme": "CEU", "rate": {"param": 4}}
+  - {"epoch": 0, "deme": "CHB", "rate": {"param": 5}}
+  - {"epoch": 0, "deme": "JPT", "rate": {"param": 6}}
+  - {"epoch": 1, "deme": "YRI", "rate": {"param": 2}}
+  - {"epoch": 1, "deme": "CEU", "rate": {"param": 4}}
+  - {"epoch": 1, "deme": "CHB", "rate": {"param": 5}}
+  - {"epoch": 2, "deme": "YRI", "rate": {"param": 2}}
+  - {"epoch": 2, "deme": "CEU", "rate": {"param": 3}}
+  - {"epoch": 3, "deme": "YRI", "rate": {"param": 2}}
+  - {"epoch": 4, "deme": "YRI", "rate": {"param": 1}}
   parameters:
   - {"ground_truth": 4.4275214734791464e-05, "lb": 1e-06, "ub": 0.01, "index": 1}
   - {"ground_truth": 2.107836937734497e-05, "lb": 1e-06, "ub": 0.01, "index": 2}
@@ -27,33 +27,33 @@ coalescence:
   - {"ground_truth": 2.091008632355808e-06, "lb": 1e-06, "ub": 0.01, "index": 6}
 growth:
   entries:
-  - {"epoch": 0, "deme": 1, "rate": {"param": 1}}
-  - {"epoch": 0, "deme": 2, "rate": {"param": 2}}
-  - {"epoch": 0, "deme": 3, "rate": {"param": 3}}
-  - {"epoch": 1, "deme": 1, "rate": {"param": 1}}
-  - {"epoch": 1, "deme": 2, "rate": {"param": 2}}
+  - {"epoch": 0, "deme": "CEU", "rate": {"param": 1}}
+  - {"epoch": 0, "deme": "CHB", "rate": {"param": 2}}
+  - {"epoch": 0, "deme": "JPT", "rate": {"param": 3}}
+  - {"epoch": 1, "deme": "CEU", "rate": {"param": 1}}
+  - {"epoch": 1, "deme": "CHB", "rate": {"param": 2}}
   parameters:
   - {"ground_truth": 0.0016000000000000003, "lb": 0.001, "ub": 0.05, "index": 1}
   - {"ground_truth": 0.0026, "lb": 0.001, "ub": 0.05, "index": 2}
   - {"ground_truth": 0.0129, "lb": 0.001, "ub": 0.05, "index": 3}
 migration:
   entries:
-  - {"epoch": 0, "source": 0, "dest": 1, "rate": {"param": 2}}
-  - {"epoch": 0, "source": 0, "dest": 2, "rate": {"param": 3}}
-  - {"epoch": 0, "source": 1, "dest": 0, "rate": {"param": 2}}
-  - {"epoch": 0, "source": 1, "dest": 2, "rate": {"param": 4}}
-  - {"epoch": 0, "source": 2, "dest": 0, "rate": {"param": 3}}
-  - {"epoch": 0, "source": 2, "dest": 1, "rate": {"param": 4}}
-  - {"epoch": 0, "source": 2, "dest": 3, "rate": {"param": 5}}
-  - {"epoch": 0, "source": 3, "dest": 2, "rate": {"param": 5}}
-  - {"epoch": 1, "source": 0, "dest": 1, "rate": {"param": 2}}
-  - {"epoch": 1, "source": 0, "dest": 2, "rate": {"param": 3}}
-  - {"epoch": 1, "source": 1, "dest": 0, "rate": {"param": 2}}
-  - {"epoch": 1, "source": 1, "dest": 2, "rate": {"param": 4}}
-  - {"epoch": 1, "source": 2, "dest": 0, "rate": {"param": 3}}
-  - {"epoch": 1, "source": 2, "dest": 1, "rate": {"param": 4}}
-  - {"epoch": 2, "source": 0, "dest": 1, "rate": {"param": 1}}
-  - {"epoch": 2, "source": 1, "dest": 0, "rate": {"param": 1}}
+  - {"epoch": 0, "source": "YRI", "dest": "CEU", "rate": {"param": 2}}
+  - {"epoch": 0, "source": "YRI", "dest": "CHB", "rate": {"param": 3}}
+  - {"epoch": 0, "source": "CEU", "dest": "YRI", "rate": {"param": 2}}
+  - {"epoch": 0, "source": "CEU", "dest": "CHB", "rate": {"param": 4}}
+  - {"epoch": 0, "source": "CHB", "dest": "YRI", "rate": {"param": 3}}
+  - {"epoch": 0, "source": "CHB", "dest": "CEU", "rate": {"param": 4}}
+  - {"epoch": 0, "source": "CHB", "dest": "JPT", "rate": {"param": 5}}
+  - {"epoch": 0, "source": "JPT", "dest": "CHB", "rate": {"param": 5}}
+  - {"epoch": 1, "source": "YRI", "dest": "CEU", "rate": {"param": 2}}
+  - {"epoch": 1, "source": "YRI", "dest": "CHB", "rate": {"param": 3}}
+  - {"epoch": 1, "source": "CEU", "dest": "YRI", "rate": {"param": 2}}
+  - {"epoch": 1, "source": "CEU", "dest": "CHB", "rate": {"param": 4}}
+  - {"epoch": 1, "source": "CHB", "dest": "YRI", "rate": {"param": 3}}
+  - {"epoch": 1, "source": "CHB", "dest": "CEU", "rate": {"param": 4}}
+  - {"epoch": 2, "source": "YRI", "dest": "CEU", "rate": {"param": 1}}
+  - {"epoch": 2, "source": "CEU", "dest": "YRI", "rate": {"param": 1}}
   parameters:
   - {"ground_truth": 0.000168, "lb": 1e-06, "ub": 0.01, "index": 1}
   - {"ground_truth": 1.14e-05, "lb": 1e-06, "ub": 0.01, "index": 2}

--- a/mrpast/from_demes.py
+++ b/mrpast/from_demes.py
@@ -134,9 +134,11 @@ def convert_from_demes(demes_file: str) -> Dict[str, Any]:
                     coal_vects[e_idx][d_idx] = param_idx
                 last_epoch = max(last_epoch, e_idx)
                 e_idx = (e_idx + 1) if (e_idx + 1) < len(epochs_by_start) else None
-        # Set the population splits.
-        for a in d.ancestors:
-            output_model["populationConversion"][last_epoch][d_idx] = name2deme[a]
+        if d.ancestors:
+            assert len(d.ancestors) == 1, "mrpast does not support admixture; only 1-to-1 population split"
+            # Set the population splits.
+            for a in d.ancestors:
+                output_model["populationConversion"][last_epoch][d_idx] = name2deme[a]
         # Mark the population as dead in the relevant epochs.
         for e_idx in range(last_epoch + 1, num_epochs - 1):
             output_model["populationConversion"][e_idx][d_idx] = float("NaN")

--- a/mrpast/helpers.py
+++ b/mrpast/helpers.py
@@ -13,19 +13,30 @@
 #
 # You should have received a copy of the GNU General Public License
 # with this program.  If not, see <https://www.gnu.org/licenses/>.
-from typing import Optional, List, Union, Dict, Any, Tuple
-from yaml import dump
+from typing import Optional, List, Union, Tuple
+from yaml import load, dump
 import json
 import os
 import subprocess
 import sys
 import tempfile
+import numpy
 import msprime
+from mrpast.model import (
+    UserModel,
+    DemeDemeRates,
+    DemeRates,
+    FloatParameter,
+    SymbolicEpochs,
+    DemeDemeEntry,
+    DemeRateEntry,
+    ParamRef,
+)
 
 try:
-    from yaml import CDumper as Dumper  # type: ignore
+    from yaml import CLoader as Loader, CDumper as Dumper  # type: ignore
 except ImportError:
-    from yaml import Dumper  # type: ignore
+    from yaml import Loader, Dumper  # type: ignore
 
 
 def which(exe: str, required=False) -> Optional[str]:
@@ -86,7 +97,7 @@ def count_lines(filename: str) -> int:
     return new_lines
 
 
-def dump_model_yaml(model: Dict[str, Any], out):
+def dump_model_yaml(model: UserModel, out):
     """
     Generic YAML dumpers tend to produce JSON or not very readable YAML.
 
@@ -94,34 +105,12 @@ def dump_model_yaml(model: Dict[str, Any], out):
     falls back to a YAML dumper otherwise.
     """
 
-    def dump_matrices(matrices: List[List[List[Union[int, float]]]], indent=2):
-        prefix = " " * indent
-        print(f"{prefix}matrices:", file=out)
-        for matrix in matrices:
-            for i, row in enumerate(matrix):
-                if i == 0:
-                    row_prefix = f"{prefix}- - "
-                else:
-                    row_prefix = f"{prefix}  - "
-                print(f"{row_prefix}{json.dumps(row)}", file=out)
-
-    def dump_vectors(vectors: List[List[Union[int, float]]], indent=2):
-        prefix = " " * indent
-        print(f"{prefix}vectors:", file=out)
-        for vector in vectors:
-            print(f"{prefix}- {json.dumps(vector)}", file=out)
-
-    def dump_parameters(parameters: List[Dict[str, float]], indent=2, no_label=False):
+    def dump_parameters(parameters: List[FloatParameter], indent=2, no_label=False):
         prefix = " " * indent
         if not no_label:
             print(f"{prefix}parameters:", file=out)
         for param in parameters:
-            for i, key in enumerate(sorted(param.keys())):
-                if i == 0:
-                    line_prefix = f"{prefix}- "
-                else:
-                    line_prefix = f"{prefix}  "
-                print(f"{line_prefix}{key}: {json.dumps(param[key])}", file=out)
+            print(f"{prefix}- {param.to_json()}", file=out)
 
     def dump_vectors_raw(vectors: List[List[Union[int, float]]], indent=2):
         prefix = " " * indent
@@ -129,41 +118,32 @@ def dump_model_yaml(model: Dict[str, Any], out):
             line_prefix = f"{prefix}- "
             print(f"{line_prefix}{json.dumps(vector)}", file=out)
 
-    keys = set(model.keys())
-    for key in (
-        "ploidy",
-        "pop_names",
-    ):
-        if key in keys:
-            keys.remove(key)
-            out.write(dump({key: model[key]}, Dumper=Dumper))
-    for key in ("coalescence", "growth"):
-        if key in keys:
-            keys.remove(key)
-            print(f"{key}:", file=out)
-            dump_vectors(model[key]["vectors"])
-            dump_parameters(model[key]["parameters"])
-    for key in ("migration",):
-        if key in keys:
-            keys.remove(key)
-            print(f"{key}:", file=out)
-            dump_matrices(model[key]["matrices"])
-            dump_parameters(model[key]["parameters"])
-    for key in ("epochTimeSplit",):
-        if key in keys:
-            keys.remove(key)
-            print(f"{key}:", file=out)
-            dump_parameters(model[key], indent=0, no_label=True)
-    for key in ("populationConversion",):
-        if key in keys:
-            keys.remove(key)
-            print(f"{key}:", file=out)
-            dump_vectors_raw(model[key], indent=0)
-    remaining = {}
-    for key in keys:
-        remaining[key] = model[key]
-    if remaining:
-        out.write(dump(remaining, Dumper=Dumper))
+    out.write(dump({"ploidy": model.ploidy}, Dumper=Dumper))
+    if model.pop_count > 0:
+        out.write(dump({"pop_count": model.pop_count}, Dumper=Dumper))
+    if model.pop_names:
+        out.write(dump({"pop_names": model.pop_names}, Dumper=Dumper))
+    print(f"coalescence:", file=out)
+    print(f"  entries:", file=out)
+    for e in model.coalescence.entries:
+        print(f"  - {e.to_json()}", file=out)
+    dump_parameters(model.coalescence.parameters)
+    if model.growth.entries:
+        print(f"growth:", file=out)
+        print(f"  entries:", file=out)
+        for e in model.growth.entries:
+            print(f"  - {e.to_json()}", file=out)
+        dump_parameters(model.growth.parameters)
+    if model.migration.entries:
+        print(f"migration:", file=out)
+        print(f"  entries:", file=out)
+        for e in model.migration.entries:
+            print(f"  - {e.to_json()}", file=out)
+        dump_parameters(model.migration.parameters)
+    print(f"epochTimeSplit:", file=out)
+    dump_parameters(model.epochs.epoch_times, indent=0, no_label=True)
+    print(f"populationConversion:", file=out)
+    dump_vectors_raw(model.pop_convert, indent=0)
 
 
 def haps2vcf(input_prefix, output_prefix, ploidy=2):
@@ -371,3 +351,55 @@ def get_best_output(filenames: List[str]) -> Tuple[Optional[str], float]:
             bestLL = negLL
             best = fn
     return (best, bestLL)
+
+
+def load_old_mrpast(yaml_file: str) -> UserModel:
+    """
+    Helper to convert old mrpast YAML files to the new format.
+    """
+    with open(yaml_file) as f:
+        config = load(f, Loader=Loader)
+        mig_params = map(FloatParameter.from_dict, config["migration"]["parameters"])
+        mig_entries = []
+        pop_count = 0
+        for e, m in enumerate(config["migration"]["matrices"]):
+            m = numpy.array(m)
+            pop_count = max(pop_count, m.shape[1])
+            for i in range(m.shape[0]):
+                for j in range(m.shape[1]):
+                    if m[i, j] != 0:
+                        mig_entries.append(
+                            DemeDemeEntry(e, i, j, ParamRef(int(m[i, j])))
+                        )
+        coal_params = map(FloatParameter.from_dict, config["coalescence"]["parameters"])
+        coal_entries = []
+        for e, m in enumerate(config["coalescence"]["vectors"]):
+            m = numpy.array(m)
+            pop_count = max(pop_count, m.shape[0])
+            for i in range(m.shape[0]):
+                if m[i] != 0:
+                    coal_entries.append(DemeRateEntry(e, i, ParamRef(int(m[i]))))
+        grow_params = map(
+            FloatParameter.from_dict,
+            config.get("growth", {"parameters": []})["parameters"],
+        )
+        grow_entries = []
+        if "growth" in config:
+            for e, m in enumerate(config["growth"]["vectors"]):
+                m = numpy.array(m)
+                for i in range(m.shape[0]):
+                    if m[i] != 0:
+                        grow_entries.append(DemeRateEntry(e, i, ParamRef(int(m[i]))))
+        epochs = SymbolicEpochs.from_config(config.get("epochTimeSplit", []))
+        pop_convert = config.get("populationConversion", []) or []
+        result = UserModel(
+            ploidy=config.get("ploidy", 2),
+            pop_count=pop_count,
+            pop_names=config.get("pop_names", []),
+            migration=DemeDemeRates(mig_entries, mig_params),
+            coalescence=DemeRates(coal_entries, coal_params),
+            epochs=epochs,
+            growth=DemeRates(grow_entries, grow_params),
+            pop_convert=pop_convert,
+        )
+        return result

--- a/mrpast/helpers.py
+++ b/mrpast/helpers.py
@@ -14,6 +14,7 @@
 # You should have received a copy of the GNU General Public License
 # with this program.  If not, see <https://www.gnu.org/licenses/>.
 from typing import Optional, List, Union, Tuple
+from copy import deepcopy
 from yaml import load, dump
 import json
 import os
@@ -104,6 +105,8 @@ def dump_model_yaml(model: UserModel, out):
     This is specific to how we want the models layed out for readability, but
     falls back to a YAML dumper otherwise.
     """
+    model = deepcopy(model)
+    model.unresolve_names()
 
     def dump_parameters(parameters: List[FloatParameter], indent=2, no_label=False):
         prefix = " " * indent

--- a/mrpast/main.py
+++ b/mrpast/main.py
@@ -44,6 +44,7 @@ from mrpast.helpers import (
     relate_polarize,
     remove_ext,
     which,
+    load_old_mrpast,
 )
 from mrpast.simulate import (
     run_simulation,
@@ -57,11 +58,7 @@ from mrpast.arginfer import (
 )
 from mrpast.model import (
     UserModel,
-    load_model_config,
-    SymbolicMatrices,
-    SymbolicEpochs,
     ModelSolverInput,
-    validate_model,
     print_model_warnings,
 )
 from mrpast.simprocess import (
@@ -305,8 +302,7 @@ def get_coal_counts(
         and description is a string describing what the samples mean (ARG samples, boostrapped, etc.)
     """
     # Load the configuration and create the symbolic model from it.
-    config = load_model_config(model_file)
-    M_symbolic = SymbolicMatrices.from_config(config["migration"])
+    model = UserModel.from_file(model_file)
 
     description = None
     if bootstrap == BootstrapOpt.none:
@@ -322,7 +318,7 @@ def get_coal_counts(
         assert False, f"Unrecognized bootstrap option {bootstrap}"
 
     number_of_groups = len(grouped_filenames)
-    deme_pair_index0 = M_symbolic.get_pair_ordering(0)
+    deme_pair_index0 = model.get_pair_ordering()
     coal_matrices = []
     if number_of_groups > 1:
         print(f"Using {number_of_groups} ARG sample with sampling method {description}")
@@ -913,11 +909,17 @@ def main():
     create_parser = subparsers.add_parser(
         CMD_INIT, help="Create an initial model, to be edited by the user."
     )
-    create_parser.add_argument(
+    init_choices = create_parser.add_mutually_exclusive_group()
+    init_choices.add_argument(
         "--from-demes",
         "-d",
         type=str,
         help="Convert a Demes YAML file into a mrpast model.",
+    )
+    init_choices.add_argument(
+        "--from-old-mrpast",
+        type=str,
+        help="Convert an old matrix-based mrpast YAML file into a current mrpast model.",
     )
 
     confidence_parser = subparsers.add_parser(
@@ -976,12 +978,6 @@ def main():
     )
 
     args = parser.parse_args()
-
-    if hasattr(args, "model"):
-        if isinstance(args.model, str):
-            validate_model(args.model)
-        elif isinstance(args.model, list):
-            [validate_model(m) for m in args.model]
 
     if args.command == CMD_SIMULATE:
         total_trees = run_simulation(
@@ -1075,7 +1071,8 @@ def main():
             assert (
                 demes is not None
             ), 'Could not find demes module; try "pip install demes"'
-            demography, _ = build_demography(args.model)
+            model = UserModel.from_file(args.model)
+            demography, _ = build_demography(model)
             print(demography.debug())
             if args.to_demes:
                 demes_graph = demography.to_demes()
@@ -1090,6 +1087,9 @@ def main():
                 file=sys.stderr,
             )
             dump_model_yaml(convert_from_demes(args.from_demes), sys.stdout)
+        elif args.from_old_mrpast is not None:
+            model = load_old_mrpast(args.from_old_mrpast)
+            dump_model_yaml(model, sys.stdout)
         else:
             print(
                 'You must pass in additional options to the "init" command. See --help',

--- a/src/objective.h
+++ b/src/objective.h
@@ -86,10 +86,13 @@ struct BoundedVariable {
     double init;
     double lb;
     double ub;
-    std::list<VariableApplication> applications;
+    std::vector<VariableApplication> applications;
     std::string description;
     double ground_truth;
+    size_t kind_index;
 };
+
+inline bool isJsonParamFixed(const json& parameter) { return (parameter["lb"] == parameter["ub"]); }
 
 /**
  * The schema describes the parameters, their bounds, and how they apply to the

--- a/test/test_models.py
+++ b/test/test_models.py
@@ -10,18 +10,19 @@ import os
 THISDIR = os.path.dirname(os.path.realpath(__file__))
 
 MODEL_5D1E = os.path.join(THISDIR, "..", "examples", "5deme1epoch.yaml")
+MODEL_6D2ES = os.path.join(THISDIR, "..", "examples", "6deme2epoch.split.yaml")
+MODEL_OOA2 = os.path.join(THISDIR, "..", "examples", "ooa_2t12.yaml")
+MODEL_OOA3 = os.path.join(THISDIR, "..", "examples", "ooa_3g09.yaml")
 
 
 class ModelTests(unittest.TestCase):
     # This test round-trips one of our example models through the Demes to/from conversion
     # and then verifies that the resulting parameters are the same.
-    def test_demes_integration(self):
-        in_model = UserModel.from_file(MODEL_5D1E)
+    def run_demes_integration(self, model_name: str):
+        in_model = UserModel.from_file(model_name)
         demography, _ = build_demography(in_model)
         demes_model = demography.to_demes()
-        # with tempfile.TemporaryDirectory() as tmpdirname:
-        if True:
-            tmpdirname = "/tmp"
+        with tempfile.TemporaryDirectory() as tmpdirname:
             demes_file = os.path.join(tmpdirname, "testing.demes.yaml")
             demes.dump(demes_model, demes_file)
             roundtrip_model = convert_from_demes(demes_file)
@@ -31,21 +32,25 @@ class ModelTests(unittest.TestCase):
                 dump_model_yaml(roundtrip_model, fout)
             UserModel.from_file(rt_model_file)
 
-            config_orig = UserModel.from_file(MODEL_5D1E)
+            config_orig = UserModel.from_file(model_name)
             config_copy = UserModel.from_file(rt_model_file)
+
+            # We want deme names, _not_ indexes, so that we can compare. NOTE: this restricts
+            # what we can do with these objects, since many methods require resolved names.
+            config_orig.unresolve_names()
+            config_copy.unresolve_names()
 
             self.assertEqual(
                 len(config_orig.coalescence.entries),
                 len(config_copy.coalescence.entries),
             )
-            for e_orig, e_copy in zip(
-                sorted(
-                    config_orig.coalescence.entries, key=lambda e: (e.epoch, e.deme)
-                ),
-                sorted(
-                    config_copy.coalescence.entries, key=lambda e: (e.epoch, e.deme)
-                ),
-            ):
+            coals_orig = sorted(
+                config_orig.coalescence.entries, key=lambda e: (e.epoch, e.deme)
+            )
+            coals_copy = sorted(
+                config_copy.coalescence.entries, key=lambda e: (e.epoch, e.deme)
+            )
+            for e_orig, e_copy in zip(coals_orig, coals_copy):
                 self.assertEqual(e_orig.epoch, e_copy.epoch)
                 self.assertEqual(e_orig.deme, e_copy.deme)
                 if isinstance(e_orig.rate, ParamRef):
@@ -53,23 +58,21 @@ class ModelTests(unittest.TestCase):
                     orig = config_orig.coalescence.get_parameter(e_orig.rate.param)
                     copy = config_copy.coalescence.get_parameter(e_copy.rate.param)
                     self.assertAlmostEqual(orig.ground_truth, copy.ground_truth, 6)
-                    self.assertAlmostEqual(orig.lb, copy.lb, 6)
-                    self.assertAlmostEqual(orig.ub, copy.ub, 6)
+                    # The bounds don't exist in the demes model, so we can't test this.
+                    # self.assertAlmostEqual(orig.lb, copy.lb, 6)
+                    # self.assertAlmostEqual(orig.ub, copy.ub, 6)
 
                 self.assertEqual(
                     len(config_orig.migration.entries),
                     len(config_copy.migration.entries),
                 )
-            for e_orig, e_copy in zip(
-                sorted(
-                    config_orig.migration.entries,
-                    key=lambda e: (e.epoch, e.source, e.dest),
-                ),
-                sorted(
-                    config_copy.migration.entries,
-                    key=lambda e: (e.epoch, e.source, e.dest),
-                ),
-            ):
+            migs_orig = sorted(
+                config_orig.migration.entries, key=lambda e: (e.epoch, e.source, e.dest)
+            )
+            migs_copy = sorted(
+                config_copy.migration.entries, key=lambda e: (e.epoch, e.source, e.dest)
+            )
+            for e_orig, e_copy in zip(migs_orig, migs_copy):
                 self.assertEqual(e_orig.epoch, e_copy.epoch)
                 self.assertEqual(e_orig.source, e_copy.source)
                 self.assertEqual(e_orig.dest, e_copy.dest)
@@ -78,8 +81,21 @@ class ModelTests(unittest.TestCase):
                     orig = config_orig.migration.get_parameter(e_orig.rate.param)
                     copy = config_copy.migration.get_parameter(e_copy.rate.param)
                     self.assertAlmostEqual(orig.ground_truth, copy.ground_truth, 6)
-                    self.assertAlmostEqual(orig.lb, copy.lb, 6)
-                    self.assertAlmostEqual(orig.ub, copy.ub, 6)
+                    # The bounds don't exist in the demes model, so we can't test this.
+                    # self.assertAlmostEqual(orig.lb, copy.lb, 6)
+                    # self.assertAlmostEqual(orig.ub, copy.ub, 6)
+
+    def test_demes_5d1e(self):
+        self.run_demes_integration(MODEL_5D1E)
+
+    def test_demes_ooa2(self):
+        self.run_demes_integration(MODEL_OOA2)
+
+    def test_demes_ooa3(self):
+        self.run_demes_integration(MODEL_OOA3)
+
+    def test_demes_6d2es(self):
+        self.run_demes_integration(MODEL_6D2ES)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The old matrix-style model specification could get confusing, especially when trying to modify existing models.

Switch to a more verbose, declarative style. The `migration`, `coalescence`, and `growth` fields still contain a `parameters` list, but now have `entries:` instead of `matrices` or `vectors`. The `entries` are a list of dictionaries that specify the epoch, the demes involved, and the rate.

The rates can now be specified as a parameter reference `{"param": <index>}` which is equivalent to the behavior before, or they can just be specified as a floating point value `<value>` which treats the parameter as _fixed_.  The solver now properly handles fixed values for all parameter types, and the numerical optimizer no longer "sees" such fixed parameters, they are just plugged into the equations as constants.

To convert an old-style mrpast model to a new-style, use `mrpast init --from-old-mrpast <old model filename>` and it will spit the new model's YAML out on `stdout`.

Also a bug fix:
* Reject Demes models that have admixture in them (more than one ancestral population in a split). Previously we just generated an incorrect mrpast model.