### PR TITLE
Don't allow admixture values to become negative

### DIFF
--- a/src/objective.cpp
+++ b/src/objective.cpp
@@ -346,7 +346,11 @@ std::vector<double> getAdmixtureValues(const ParameterSchema& schema, double con
         for (const size_t otherIndex : schema.m_aParams.at(index).oneMinus) {
             sum += admixtureValues.at(otherIndex);
         }
-        admixtureValues.at(index) = 1.0 - sum;
+        if (sum < 1.0) {
+            admixtureValues.at(index) = 1.0 - sum;
+        } else {
+            admixtureValues.at(index) = 0.0;
+        }
     }
     return std::move(admixtureValues);
 }


### PR DESCRIPTION
Some admixture parameters are determined completely by the sum of other admixture parameters (1.0 - sum, actually). Depending on the bounds chosen by the user, this can lead to negative admixture proportions. Prevent this from happening, and always zero out such parameters.

It is still _possible_ that the sum of all admixture proportions could exceed 1, but in practice for a reasonable model this does not happen for the MLE, just for random initialization values.