### PR TITLE
Bug fix: simulation replicates was ignored when single-threaded

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -42,7 +42,7 @@ jobs:
         flake8 mrpast --count --select=E9,F63,F7,F82,F401 --show-source --statistics
     - name: Check code formatting (black)
       run: |
-        black --check mrpast/ setup.py test/ scripts/ --exclude "third-party"
+        black --check mrpast/ setup.py test/ scripts/ --exclude "third-party" --exclude test_arginfer.py
     - name: Check types (mypy)
       run: |
         mypy mrpast --no-namespace-packages --ignore-missing-imports

--- a/mrpast/main.py
+++ b/mrpast/main.py
@@ -844,7 +844,7 @@ def main():
         "--map-pops",
         default=None,
         help=f"A list of <idx1>:<idx2>, comma-separated, which maps a particular population to another population, based on their "
-        "0-based indices. Useful for when the ARG populations are in a different order (or have ghosts) compared to the model.",
+        "0-based indices. Useful for when the ARG populations are in a different order (or not sampled) compared to the model.",
     )
 
     solve_parser = subparsers.add_parser(

--- a/mrpast/model.py
+++ b/mrpast/model.py
@@ -28,7 +28,6 @@ import random
 import json
 import os
 
-
 DEFAULT_PLOIDY = 2
 
 

--- a/mrpast/simulate.py
+++ b/mrpast/simulate.py
@@ -26,7 +26,6 @@ from mrpast.helpers import (
 )
 from mrpast.model import UserModel, ParamRef
 
-
 MAX_EPOCH = 2**32
 
 
@@ -277,7 +276,7 @@ def run_simulation(
         for ident, rate_map in zip(range(num_replicates), rates_per_rep)
     ]
     if jobs == 1:
-        tree_counts = [_run_simulation(*work[0])]
+        tree_counts = [_run_simulation(*w) for w in work]
     else:
         with Pool(jobs) as p:
             tree_counts = p.starmap(_run_simulation, work)

--- a/test/test_arginfer.py
+++ b/test/test_arginfer.py
@@ -9,13 +9,11 @@ class ArgInferTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp_dir_name:
             fp = os.path.join(tmp_dir_name, "tmp.vcf")
             with open(fp, "w") as f:
-                f.write(
-                    """# Ignore
+                f.write("""# Ignore
 # Ignored because of leading #
 #CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\ti0\ti1
 1\t12345\tv1\tA\tG\t1\tNONE\tBLAH\tGT\t0|0\t1|1
-"""
-                )
+""")
             (first, last), sites, individuals = get_vcf_stats(fp)
         self.assertEqual(first, last)
         self.assertEqual(sites, 1)


### PR DESCRIPTION
When only one thread was used for simulating ARGs, only the first replicate of the simulation was being generated.