### PR TITLE
Fix bug with --leave-out; improve docs for --leave-out/--map-pops

### DIFF
--- a/docs/concepts.rst
+++ b/docs/concepts.rst
@@ -159,3 +159,14 @@ All three ARG methods integrated with mrpast work best with polarized data. mrpa
 ``mrpast polarize``. An ancestral FASTA sequence is required for performing polarization. The GRCh37 human ancestral sequence can be found via the
 `relate documentation <https://myersgroup.github.io/relate/input_data.html#Data>`_, and GRCh38 human ancestral sequence can be found from
 Ensembl `here <https://ftp.ensembl.org/pub/release-112/fasta/ancestral_alleles/>`_.
+
+Model/ARG Population Mismatches
+-------------------------------
+
+You might end up in a situation where the populations in an ARG that you want to use do not match up exactly to the populations in a model
+that you want to use. A few examples are:
+
+1. You inferred an ARG containing 3 populations, but you want to use a model that only uses two of them. You could handle this by using the ``--leave-out`` option when calling ``mrpast process``, or you could downsample the ARG(s) first to remove the unneeded samples (see `tskit.TreeSequence.simplify() <https://tskit.dev/tskit/docs/stable/python-api.html#tskit.TreeSequence.simplify>`_), or you could reinfer the ARGs with only the relevant samples. Note that having these extra samples will affect ARG inference; whether this matters will depend on your use case.
+2. You inferred an ARG containing 4 populations, but you want to use a model that contains another (5th) population. Here, you need to treat one of these populations as unsampled and use the ``--map-pops`` option to specify how the ARG populations map to model populations.
+
+See the `examples <examples.html>`_ page for more details.

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -1,0 +1,46 @@
+.. _examples:
+
+Examples
+========
+
+This page shows some very brief examples for how to use the ``mrpast`` command line in certain scenarios.
+
+ARG has too many populations
+----------------------------
+
+In this example, we'll simulate some ARGs with 3 populations and use them in a model with 2 populations.
+
+::
+
+  mkdir ooa3.simdata/
+  mkdir ooa3_output/
+  mkdir ooa2_output/
+
+  # Simulate our ARGs first (2 ARGs, 10MB length each, 10 individuals per population, 3 population model)
+  mrpast simulate -r 2 --seq-len 10000000 -n 10 examples/ooa_3g09.yaml ooa3.simdata/ooa3_
+
+  # Use them in the same 3-population model
+  mrpast process --out-dir ooa3_output examples/ooa_3g09.yaml ooa3.simdata/ooa3__
+
+  # Now use them in the 2-population model by removing the 3rd population from the ARG
+  mrpast process --leave-out 2 --out-dir ooa2_output examples/ooa2_2t12.yaml ooa3.simdata/ooa3__
+
+  # Same thing, but lets also rearrange the order of the populations that we map. So we'll let the 2nd
+  # and 3rd population from the ARG be used in our model, and drop the 1st population.
+  mrpast process --leave-out 0 --map-pops 1:0,2:1 --out-dir ooa2_output examples/ooa2_2t12.yaml ooa3.simdata/ooa3__
+
+ARG has too few populations
+---------------------------
+
+In the opposite scenario from above, we'll use the same simulated ARGs (3 populations) and use them in a model
+with 4 populations, which means we need to treat one of them as unsampled (we won't have any coalescences from
+the ARG to use).
+
+::
+
+  mkdir ooa4_output/
+
+  # The model has 4 populations (0, 1, 2, 3) and we choose to map the 3 ARG populations to the first
+  # 3 populations of that model. For the last mapping, we just need to choose a number that is NOT in
+  # the ARG's populations and map it to "3" (the 4th population). Any number will do - here we use 100.
+  mrpast process --map-pops 0:0,1:1,2:2,100:3 --out-dir ooa4_output/ ../examples/ooa_4j17.yaml ooa3.simdata/ooa3__

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -77,5 +77,6 @@ Use the links below or on the left menu-bar to learn more.
   Examining results <results>
   Using real data <real_data>
   Creating/modifying models <modeling>
+  Very short examples <examples>
   python_api
 

--- a/mrpast/helpers.py
+++ b/mrpast/helpers.py
@@ -43,6 +43,10 @@ except ImportError:
     from yaml import Loader, Dumper  # type: ignore
 
 
+class UserInputError(Exception):
+    pass
+
+
 def which(exe: str, required=False) -> Optional[str]:
     """
     Find the named executable, first via system PATH and then via the Python PATH.

--- a/mrpast/main.py
+++ b/mrpast/main.py
@@ -48,6 +48,7 @@ from mrpast.helpers import (
     which,
     load_old_mrpast,
     one_file_or_one_per_chrom,
+    UserInputError,
 )
 from mrpast.simulate import (
     run_simulation,
@@ -225,13 +226,19 @@ def get_popsummary_from_args(
     result: List[Tuple[str, int]] = []
     for tf in tree_files:
         ts = tskit.load(tf)
+        # The ARG or the Model can have more populations than the other. When the ARG has more
+        # populations, --leave-out must be used to drop some of them. When the Model has more,
+        # those populations can remain unsampled from the ARG and inference can proceed.
         largest_mapped = 0
         if pop_idx_map:
             largest_mapped = max(pop_idx_map.values())
         pop2names = ["N/A" for _ in range(max(ts.num_populations, largest_mapped + 1))]
         for pop in ts.populations():
-            pop_id = pop_idx_map.get(pop.id, pop.id)
-            pop2names[pop_id] = pop.metadata.get("name", f"pop_{pop_id}")
+            if pop.id in leave_out_pops:
+                del pop2names[pop.id]
+            else:
+                pop_id = pop_idx_map.get(pop.id, pop.id)
+                pop2names[pop_id] = pop.metadata.get("name", f"pop_{pop_id}")
         assert all(map(lambda pstr: len(pstr) > 0, pop2names))
         pop2count = [0 for _ in pop2names]
         for tree in ts.trees():
@@ -1084,31 +1091,37 @@ def main():
 
         leave_out = parse_intlist(args.leave_out)
 
-        process_ARGs(
-            args.model,
-            args.arg_prefix,
-            args.suffix,
-            args.jobs,
-            do_solve=args.solve,
-            out_dir=args.out_dir,
-            add_ground_truth=args.add_ground_truth,
-            num_times=num_times,
-            replicates=args.replicates,
-            bootstrap=args.bootstrap,
-            bootstrap_iter=args.bootstrap_iter,
-            max_generation=args.max_generation,
-            tree_sample_rate=args.tree_sample_rate,
-            min_time_unit=args.min_time_unit,
-            leave_out=leave_out,
-            group_by=args.group_by,
-            time_slice_str=args.time_slices,
-            verbose=args.verbose,
-            rate_maps=args.rate_maps,
-            rate_map_threshold=args.rate_map_threshold,
-            left_skew_times=left_skew,
-            seed=args.seed,
-            pop_idx_map=pop_idx_map,
-        )
+        try:
+            process_ARGs(
+                args.model,
+                args.arg_prefix,
+                args.suffix,
+                args.jobs,
+                do_solve=args.solve,
+                out_dir=args.out_dir,
+                add_ground_truth=args.add_ground_truth,
+                num_times=num_times,
+                replicates=args.replicates,
+                bootstrap=args.bootstrap,
+                bootstrap_iter=args.bootstrap_iter,
+                max_generation=args.max_generation,
+                tree_sample_rate=args.tree_sample_rate,
+                min_time_unit=args.min_time_unit,
+                leave_out=leave_out,
+                group_by=args.group_by,
+                time_slice_str=args.time_slices,
+                verbose=args.verbose,
+                rate_maps=args.rate_maps,
+                rate_map_threshold=args.rate_map_threshold,
+                left_skew_times=left_skew,
+                seed=args.seed,
+                pop_idx_map=pop_idx_map,
+            )
+        except UserInputError as e:
+            print("", file=sys.stderr)
+            print("FAILURE: Invalid user input", file=sys.stderr)
+            print(e, file=sys.stderr)
+            exit(5)
         header = ["Model Population", "ARG Population", "Haploid Samples"]
         arg_pops = get_popsummary_from_args(
             args.arg_prefix,
@@ -1120,7 +1133,7 @@ def main():
         print()
         if len(arg_pops) != len(model.pop_names):
             print(
-                f"ERROR: Model has {len(model.pop_names)} populatons, but ARG only has {len(arg_pops)}",
+                f"ERROR: Model has {len(model.pop_names)} populatons, but the ARG has {len(arg_pops)}",
                 file=sys.stderr,
             )
             fail = True

--- a/mrpast/simprocess.py
+++ b/mrpast/simprocess.py
@@ -27,7 +27,7 @@ import numpy as np
 import orjson
 import tskit
 
-from mrpast.helpers import count_lines
+from mrpast.helpers import count_lines, UserInputError
 from mrpast.model import PopMap
 
 DemePairIndex = Dict[Tuple[int, int], int]
@@ -467,7 +467,13 @@ def process_coal_file(
                 pop_i = pop_idx_map.get(pop_i, pop_i)
                 pop_j = int(pop_j)
                 pop_j = pop_idx_map.get(pop_j, pop_j)
-                a_b = deme_pair_to_index[pop_i, pop_j]
+                try:
+                    a_b = deme_pair_to_index[pop_i, pop_j]
+                except KeyError as e:
+                    max_refd_pop = max(pop_i, pop_j)
+                    raise UserInputError(
+                        f"Data from the ARG(s) have at least {max_refd_pop+1} populations, which exceeds the population count in the model"
+                    )
                 # Add a sample for a particular tree, Markov state a_b, discretized
                 # time tau, and coalescence "weight" w.
                 sampler.add_sample(tree_number, a_b, discretize(t), w)

--- a/test/test_endtoend.py
+++ b/test/test_endtoend.py
@@ -6,12 +6,14 @@ import os
 import subprocess
 import tempfile
 import unittest
-import glob
+from typing import List, Dict
 
 THISDIR = os.path.dirname(os.path.realpath(__file__))
 
 MODEL_5D1E = os.path.join(THISDIR, "..", "examples", "5deme1epoch.yaml")
 MODEL_OOA3 = os.path.join(THISDIR, "..", "examples", "ooa_3g09.yaml")
+MODEL_OOA2 = os.path.join(THISDIR, "..", "examples", "ooa_2t12.yaml")
+MODEL_OOA4 = os.path.join(THISDIR, "..", "examples", "ooa_4j17.yaml")
 
 try:
     MRPAST = [subprocess.check_output(["which", "mrpast"]).decode("utf-8").strip()]
@@ -45,6 +47,37 @@ class EndToEndTests(unittest.TestCase):
         self.assertTrue(os.path.isfile(outfile))
         return outfile
 
+    def process(
+        self,
+        model_file: str,
+        tmpdirname: str,
+        leave_out: List[int] = [],
+        pop_map: Dict[int, int] = {},
+    ):
+        arg_prefix = os.path.join(tmpdirname, "test_arg")
+        extra_args = []
+        if leave_out:
+            extra_args.extend(["--leave-out", ",".join(map(str, leave_out))])
+        if pop_map:
+            extra_args.extend(
+                ["--map-pops", ",".join([f"{k}:{v}" for k, v in pop_map.items()])]
+            )
+        command = list(
+            map(
+                str,
+                MRPAST
+                + [
+                    "process",
+                ]
+                + extra_args
+                + [
+                    model_file,
+                    arg_prefix,
+                ],
+            )
+        )
+        subprocess.check_call(command)
+
     def test_demes_5d1e(self):
         with tempfile.TemporaryDirectory() as tmpdirname:
             self.simulate(MODEL_5D1E, tmpdirname)
@@ -52,6 +85,17 @@ class EndToEndTests(unittest.TestCase):
     def test_demes_ooa3(self):
         with tempfile.TemporaryDirectory() as tmpdirname:
             self.simulate(MODEL_OOA3, tmpdirname)
+
+            # Now we process this simulated data three separate ways:
+            # 1. With the same model that generated it.
+            self.process(MODEL_OOA3, tmpdirname)
+            # 2. With a model that contains _fewer_ populations, here we have to drop
+            #    one of the populations and make sure the mapping is correct.
+            self.process(MODEL_OOA2, tmpdirname, leave_out=[2])
+            # 3. With a model that contains _more_ populations, here we have to specify
+            #    the population mapping, which can include mapping a non-existing ARG
+            #    population to the last population (which treats it as unsampled).
+            self.process(MODEL_OOA4, tmpdirname, pop_map={0: 0, 1: 1, 2: 2, 3: 3})
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Improved the errors/messages around --leave-out and --map-pops, and fixed an issue where the filtering was throwing an assert.

The "concepts" and "examples" (new) documentation pages now discuss these two options. In general, you can use them to handle mismatches between the ARGs and the models, as far as the number of populations. But users should also consider that the ARG inference results themselves may differ depending on what populations are included.