### PR TITLE
Switch "mrpast confidence" to use bootstrap method by default

### DIFF
--- a/docs/results.rst
+++ b/docs/results.rst
@@ -22,28 +22,25 @@ Parameter confidence intervals
 
 There are two methods for producing confidence intervals, but the ``mrpast confidence`` command is used for both.
 
-Theoretical confidence intervals
---------------------------------
-
-``mrpast confidence solver_output.json > solver_output.gim.json`` will make a copy of ``solver_output.json`` that
-contains a confidence interval for each parameter (using the Godambe Information Matrix formulation). These intervals
-can be examined using :py:meth:`mrpast.result.load_json_pandas`. Example:
-
-::
-
-  from mrpast.result import load_json_pandas
-  dataframe = load_json_pandas("solver_output.gim.json", interval_field="gim_ci")
-
 Bootstrap confidence intervals
 ------------------------------
 
-``mrpast confidence --bootstrap solver_output.json`` can be pretty slow (hint: use ``-j <threads>`` to speed it up), as it runs every
+``mrpast confidence solver_output.json`` can be pretty slow (hint: use ``-j <threads>`` to speed it up), as it runs every
 bootstrap sample through the maximum likelihood solver and produces results in two places:
 
 1. Directory ``solver_output.bootstrap.out/`` which contains all of the intermediate solver results for every bootstrap sample.
 2. File ``solver_output.bootstrap.csv`` which contains a summary of all of the parameter and likelihood values for every bootstrap sample.
 
-The confidence intervals are not actually in either output, you need to use :py:meth:`mrpast.result.summarize_bootstrap_data`. Example:
+The confidence intervals are not actually in either output, you need to use either ``mrpast show`` or
+:py:meth:`mrpast.result.summarize_bootstrap_data`. Examples:
+
+::
+
+  mrpast show solver_output.bs_summary.csv
+
+
+OR
+
 
 ::
 
@@ -55,6 +52,32 @@ The confidence intervals are not actually in either output, you need to use :py:
 
   # The summarized dataframe, which contains the mean or median parameter values, and their confidence intervals.
   sum_dataframe = summarize_bootstrap_data(raw_dataframe, use_median=True, interval_conf=0.95)
+
+
+Theoretical confidence intervals
+--------------------------------
+
+Using the GIM-based confidence intervals is much faster, but likely less accurate, than using
+the bootstrapped intervals. The bootstrapped intervals are recommended for use, unless you are
+using a model so large that bootstrapping is computationally infeasible (in which case, the
+confidence intervals should be taken with a grain of salt).
+
+``mrpast confidence --gim solver_output.json`` will make a copy of ``solver_output.json``  (``solver_output.gim.json``) that
+contains a confidence interval for each parameter (using the Godambe Information Matrix formulation). These intervals
+can be examined using :py:meth:`mrpast.result.load_json_pandas`. Example:
+
+::
+
+  from mrpast.result import load_json_pandas
+  dataframe = load_json_pandas("solver_output.gim.json", interval_field="gim_ci")
+
+
+It also outputs a summary ``.csv`` file that can be used with ``mrpast show``:
+
+::
+
+  mrpast show solver_output.gim_summary.csv
+
 
 Model selection
 ~~~~~~~~~~~~~~~
@@ -108,8 +131,8 @@ This command will fail if you have not previously run:
 ::
 
   # Very SLOW! Solves for all bootstrap samples
-  mrpast confidence -j 8 --bootstrap best.modelA.out.json
-  mrpast confidence -j 8 --bootstrap best.modelB.out.json 
+  mrpast confidence -j 8 best.modelA.out.json
+  mrpast confidence -j 8 best.modelB.out.json
 
 
 The ``modelA_modelB.bootstrap.AIC.json`` output JSON has the same format as the non-bootstrap version.
@@ -133,6 +156,6 @@ The result of ``mrpast solve`` or ``mrpast process --solve`` can be imported as 
 Dataframe for bootstrap results
 -------------------------------
 
-The result of ``mrpast confidence --bootstrap`` can also be imported as a dataframe using
+The result of ``mrpast confidence`` can also be imported as a dataframe using
 :py:meth:`mrpast.result.summarize_bootstrap_data`. See the example above. The bootstrap results
 contain more than just confidence interval information.

--- a/mrpast/main.py
+++ b/mrpast/main.py
@@ -78,6 +78,7 @@ from mrpast.simprocess import (
 from mrpast.result import (
     load_json_pandas,
     tab_show,
+    summarize_bootstrap_data,
 )
 
 DEFAULT_INDIVIDUALS = 10  # per population
@@ -1010,10 +1011,23 @@ def main():
         "solved_result", help="A JSON file output by the solver."
     )
     confidence_parser.add_argument(
+        "--simple-expect",
+        action="store_true",
+        help="NOT RECOMMENDED. Calculate the Jacobian from the MLE, instead of averaging the gradients over "
+        "many samples (bootstraps or ARG samples). This can help with some numerical issues, but the resulting "
+        "parameter intervals are likely to be over-confident.",
+    )
+    confidence_parser.add_argument(
         "--bootstrap",
         "-b",
         action="store_true",
-        help="Solve for all bootstrapped samples instead of using GIM (theoretical).",
+        help="Solve MLE for all bootstrapped samples; can be very slow on large models!",
+    )
+    confidence_parser.add_argument(
+        "--gim",
+        "-g",
+        action="store_true",
+        help="Use the GIM method of computing confidence intervals. Faster, but possibly less accurate than bootstrapping.",
     )
     confidence_parser.add_argument(
         "--replicates",
@@ -1218,14 +1232,46 @@ def main():
             )
             exit(1)
     elif args.command == CMD_CONFIDENCE:
-        if not args.bootstrap:
-            result = subprocess.check_output(
-                [eval_exe, "intervals", args.solved_result]
+        if args.bootstrap:
+            print(
+                "WARNING: --bootstrap is now the default, and no longer needs to be specified. Use --gim to get GIM-based results."
             )
+        base_name = remove_ext(os.path.basename(args.solved_result))
+        if args.gim:
+            cmd = [eval_exe, "intervals", args.solved_result]
+            if args.simple_expect:
+                cmd.append("--simple-expect")
+                print(
+                    "WARNING: --simple-expect is EXPERIMENTAL, and may result in overly-confident parameter intervals.",
+                    file=sys.stderr,
+                )
+            result = subprocess.check_output(cmd)
             resulting_obj = json.loads(result.decode("utf-8"))
-            print(json.dumps(resulting_obj, indent=2))
+
+            json_file = f"{base_name}.gim.json"
+            with open(json_file, "w") as fout:
+                fout.write(json.dumps(resulting_obj, indent=2))
+            print(f"Wrote output with GIM 95% conf. intervals to {json_file}")
+
+            csv_file = f"{base_name}.gim_summary.csv"
+            summary_df = load_json_pandas(json_file, interval_field="gim_ci")
+            summary_df.index.name = "param_index"
+            summary_df.drop(
+                columns=[
+                    "gim_ci",
+                    "final",
+                    "kind",
+                    "kind_index",
+                    "lb",
+                    "ub",
+                    "init",
+                    "ground_truth",
+                ]
+            ).to_csv(csv_file, index=False)
+            print(
+                f"Wrote parameter summary (95% conf. intervals) DataFrame to {csv_file}"
+            )
         else:
-            base_name = remove_ext(os.path.basename(args.solved_result))
             out_dir = f"{base_name}.bootstrap.out"
             if os.path.exists(out_dir):
                 print(
@@ -1260,6 +1306,7 @@ def main():
                 print(f"Best result for matrix {i}: {best_output}")
                 if best_output is not None:
                     best_df = load_json_pandas(best_output)
+                    best_df.index.name = "param_index"
                     sample_column = [i for _ in range(len(best_df))]
                     best_df["sample"] = sample_column
                     negLL_column = [best_negLL for _ in range(len(best_df))]
@@ -1267,7 +1314,17 @@ def main():
                     result_df = pd.concat([result_df, best_df])
             csv_file = f"{base_name}.bootstrap.csv"
             result_df.to_csv(csv_file)
-            print(f"Wrote DataFrame to {csv_file}")
+            print(f"Wrote raw results DataFrame to {csv_file}")
+
+            csv_file = f"{base_name}.bs_summary.csv"
+            summary_df = summarize_bootstrap_data(
+                result_df, use_median=True, interval_conf=0.95
+            )
+            summary_df.to_csv(csv_file, index=False)
+            print(
+                f"Wrote parameter summary (95% conf. intervals) DataFrame to {csv_file}"
+            )
+
     elif args.command == CMD_POLARIZE:
         out_file = args.out_prefix + ".vcf"
         if os.path.exists(out_file):
@@ -1277,7 +1334,11 @@ def main():
         print(f"Finished polarizing. Wrote {out_file}")
         stats.print(sys.stdout, prefix="  ")
     elif args.command == CMD_SHOW:
-        tab_show(args.solved_result, args.sort_by)
+        if args.solved_result.endswith(".csv"):
+            df = pd.read_csv(args.solved_result)
+            print(df)
+        else:
+            tab_show(args.solved_result, args.sort_by)
     elif args.command == CMD_SELECT:
         cmd = [eval_exe, "select"]
         if args.bootstrap:

--- a/mrpast/result.py
+++ b/mrpast/result.py
@@ -228,7 +228,11 @@ def summarize_bootstrap_data(
     ), f"Unsupported confidence {interval_conf}; try 1.0, 0.99, 0.95, 0.9, or 0.75"
 
     def get_singular(df, label, field):
-        value = set(df[df["label"] == label][field])
+        items = df[df["label"] == label][field]
+        # We string-ify lists so that we can uniquify them
+        if items.dtype == object:
+            items = items.astype(str)
+        value = set(items)
         assert len(value) == 1
         return list(value)[0]
 
@@ -263,10 +267,9 @@ def summarize_bootstrap_data(
                 "std": std_err,
                 "Epochs": get_singular(bootstrap_df, label, "Epochs"),
                 "covered": (truth >= (value - c95_low) and truth <= (value + c95_hi)),
-                "param_index": get_singular(bootstrap_df, label, "Unnamed: 0"),
             }
         )
-    return pd.DataFrame.from_dict(new_data).sort_values("param_index")
+    return pd.DataFrame.from_dict(new_data).sort_values("label")
 
 
 def draw_graphs(

--- a/src/common.h
+++ b/src/common.h
@@ -107,4 +107,41 @@ constexpr auto MRP_OPT_ALG = NLOPT_LN_SBPLX; // Best in initial testing
 // GRADIENT-BASED:
 // constexpr auto MRP_OPT_ALG = NLOPT_LD_LBFGS; // Best of gradient methods in initial testing
 
+/**
+ * Exception thrown to notify the user of some condition that they can potentially address (model
+ * problem, user input problem, numerical issue with their results, etc.)
+ */
+class UserNotification : public std::runtime_error {
+public:
+    explicit UserNotification(char const* const message)
+        : std::runtime_error(message) {}
+};
+
+#define user_exc_check(condition, msg)                                                                                 \
+    do {                                                                                                               \
+        if (!(condition)) {                                                                                            \
+            std::stringstream ssErr;                                                                                   \
+            ssErr << msg;                                                                                              \
+            throw UserNotification(ssErr.str().c_str());                                                               \
+        }                                                                                                              \
+    } while (0)
+
+#define DUMP_MATRIX(m, desc)                                                                                           \
+    do {                                                                                                               \
+        std::cerr << "% " << desc << ": " << std::endl;                                                                \
+        std::cerr << "[";                                                                                              \
+        for (Eigen::Index i = 0; i < (m).rows(); i++) {                                                                \
+            if (i > 0) {                                                                                               \
+                std::cerr << "; ";                                                                                     \
+            }                                                                                                          \
+            for (Eigen::Index j = 0; j < (m).cols(); j++) {                                                            \
+                if (j > 0) {                                                                                           \
+                    std::cerr << ", ";                                                                                 \
+                }                                                                                                      \
+                std::cerr << (m).coeff(i, j);                                                                          \
+            }                                                                                                          \
+        }                                                                                                              \
+        std::cerr << "]" << std::endl;                                                                                 \
+    } while (0)
+
 #endif /* MRP_SOLVER_COMMON_H */

--- a/src/derivatives.h
+++ b/src/derivatives.h
@@ -339,7 +339,7 @@ inline MatrixXd calculateSensitivity(CostFunc& cost, const std::vector<double>& 
     std::vector<double> paramsWorking = optParams;
 
     // We are computing an approximation to the expectation of the second order
-    // gradeints, for which we just use the optimal parameters (theta-hat) and the
+    // gradients, for which we just use the optimal parameters (theta-hat) and the
     // "true" observed data (coalescence matrix).
     cost.resetCMatrixCache();
 
@@ -426,8 +426,10 @@ calculateVariability(CostFunc& cost, const std::vector<double>& optParams, const
 #endif
     }
 
+#if DEBUG_VARIANCE
+    std::vector<MatrixXd> gradients;
+#endif
     MatrixXd expectedJ = MatrixXd::Zero(N, N);
-    VectorXd expectedGrad = VectorXd::Zero(N);
     for (size_t sample = 0; sample < numSamples; sample++) {
         if (bootstrap) {
             // Only use the ith coal matrix
@@ -445,9 +447,23 @@ calculateVariability(CostFunc& cost, const std::vector<double>& optParams, const
             gradient[j] = riddersD1(cost, paramsWorking, directions, j, step);
 #endif
         }
-        expectedJ += (gradient * gradient.transpose());
+        auto currentJ = (gradient * gradient.transpose());
+        expectedJ += currentJ;
+#if DEBUG_VARIANCE
+        gradients.emplace_back(std::move(currentJ));
+#endif
     }
     expectedJ /= (double)numSamples;
+
+#if DEBUG_VARIANCE
+    MatrixXd varianceJ = MatrixXd::Zero(N, N);
+    for (size_t sample = 0; sample < numSamples; sample++) {
+        auto diff = (gradients[sample] - expectedJ);
+        varianceJ += (diff.array() * diff.array()).matrix();
+    }
+    varianceJ /= (double)numSamples;
+    DUMP_MATRIX(varianceJ, "varianceJ");
+#endif
 
     return std::move(expectedJ);
 }

--- a/src/mrp_eval.cpp
+++ b/src/mrp_eval.cpp
@@ -43,6 +43,8 @@ using json = nlohmann::json;
 // more numerically stable than taking the inverse of J and GIM.
 #define SINGLE_INVERSE_CALCULATION 1
 
+#define TRACE_MATRICES 0
+
 #if TRACE_MATRICES
 #define TRACE_MATRIX(m, desc)                                                                                          \
     do {                                                                                                               \
@@ -154,9 +156,9 @@ std::vector<double> loadNegLL(std::ifstream& inStream) {
 }
 
 // Return the inverse of the given matrix.
-inline MatrixXd invert(const MatrixXd& m) {
+inline MatrixXd invert(const MatrixXd& m, const char* matrixDesc) {
     Eigen::FullPivLU<MatrixXd> lu(m);
-    RELEASE_ASSERT(lu.isInvertible());
+    user_exc_check(lu.isInvertible(), matrixDesc << " is not invertible; try --fix-non-invertible");
     return lu.inverse();
 }
 
@@ -268,6 +270,13 @@ void intervalsCommand(args::Subparser& parser) {
                                 "When the H matrix is non-invertible, try holding a single parameter constant (usually "
                                 "an epoch time) to see if it becomes invertible",
                                 {'f', "fix-non-invertible"});
+    args::Flag simpleExpect(parser,
+                            "simpleExpect",
+                            "Compute the expected gradient from the MLE directly, instead of averaging the gradients "
+                            "over all samples (boostraps, ARGs, etc). This can help with numerical issues on certain "
+                            "models/samples but WILL result in overly confident confidence intervals.",
+                            {"simple-expect"});
+
     parser.Parse();
     if (!inputFile) {
         std::cerr << parser << std::endl;
@@ -308,20 +317,28 @@ void intervalsCommand(args::Subparser& parser) {
     json outputResult = cost.m_schema.toJsonOutput(paramVector.data(), prevResultJson.at("negLL"));
     VectorXd uncertaintySE = VectorXd::Zero(SIZE_T_TO_INDEX(paramVector.size()));
 
+    const char* gradientErr = "try switching to bootstrap-based intervals";
+    const char* hessianErr = "try using fewer time slices or switching to bootstrap-based intervals";
+
     size_t leftOut = std::numeric_limits<size_t>::max();
     auto [variabilityJ, sensitivityH] =
-        getJandH(cost, paramVector, leftOut, /*bootstrap=*/true, /*fixNonInvertible=*/fixNonInvertible);
+        getJandH(cost, paramVector, leftOut, /*bootstrap=*/!simpleExpect, /*fixNonInvertible=*/fixNonInvertible);
+    user_exc_check(variabilityJ.allFinite(), "J (jacobian/gradients) is not finite; " << gradientErr);
+    user_exc_check(sensitivityH.allFinite(), "H (hessian) is not finite; " << hessianErr);
 
 #if SINGLE_INVERSE_CALCULATION
-    MatrixXd H_inverse = invert(sensitivityH);
+    MatrixXd H_inverse = invert(sensitivityH, "H matrix");
+    user_exc_check(H_inverse.allFinite(), "inverse(H) is not finite; " << hessianErr);
     MatrixXd GIM_inverse = H_inverse * variabilityJ * H_inverse;
     TRACE_MATRIX(GIM_inverse, "GIM_inverse");
+    user_exc_check(GIM_inverse.allFinite(), "inverse(G) is not finite; " << gradientErr);
 #else
-    MatrixXd GIM = (sensitivityH * invert(variabilityJ)) * sensitivityH;
+    MatrixXd GIM = (sensitivityH * invert(variabilityJ, "J matrix")) * sensitivityH;
     TRACE_MATRIX(GIM, "GIM");
-    MatrixXd GIM_inverse = invert(GIM);
+    MatrixXd GIM_inverse = invert(GIM, "GIM matrix");
 #endif
     const VectorXd gimDiag = GIM_inverse.diagonal().array().sqrt();
+    user_exc_check(gimDiag.allFinite(), "sqrt(diag(GIM)) is not finite; " << gradientErr);
     RELEASE_ASSERT(gimDiag.size() == paramVector.size() ||
                    gimDiag.size() == (paramVector.size() - 1) && leftOut < paramVector.size());
 
@@ -430,7 +447,7 @@ void selectCommand(args::Subparser& parser) {
         size_t leftOut = std::numeric_limits<size_t>::max();
         auto [variabilityJ, sensitivityH] =
             getJandH(cost, paramVector, leftOut, /*bootstrap=*/true, /*fixNonInvertible=*/fixNonInvertible);
-        const double currentTrace = (variabilityJ * invert(sensitivityH)).trace();
+        const double currentTrace = (variabilityJ * invert(sensitivityH, "H matrix")).trace();
         if (currentTrace <= 0) {
             std::cerr << "WARNING: Non-positive trace value of " << currentTrace << std::endl;
             if (failOnNegTrace) {
@@ -647,6 +664,10 @@ int main(int argc, char** argv) {
     } catch (args::Error& e) {
         std::cerr << e.what() << std::endl << parser;
         return 1;
+    } catch (UserNotification& e) {
+        std::cerr << std::endl;
+        std::cerr << "ERROR! " << e.what() << std::endl;
+        return 2;
     }
     return 0;
 }

--- a/src/objective.cpp
+++ b/src/objective.cpp
@@ -42,24 +42,6 @@ using Eigen::VectorXd;
 // to produce slightly better point estimates with definitely better confidence intervals.
 #define FEWER_SUBTRACTIONS_PER_EPOCH 1
 
-#define DUMP_MATRIX(m, desc)                                                                                           \
-    do {                                                                                                               \
-        std::cerr << "% " << desc << ": " << std::endl;                                                                \
-        std::cerr << "[";                                                                                              \
-        for (Eigen::Index i = 0; i < (m).rows(); i++) {                                                                \
-            if (i > 0) {                                                                                               \
-                std::cerr << "; ";                                                                                     \
-            }                                                                                                          \
-            for (Eigen::Index j = 0; j < (m).cols(); j++) {                                                            \
-                if (j > 0) {                                                                                           \
-                    std::cerr << ", ";                                                                                 \
-                }                                                                                                      \
-                std::cerr << (m).coeff(i, j);                                                                          \
-            }                                                                                                          \
-        }                                                                                                              \
-        std::cerr << "]" << std::endl;                                                                                 \
-    } while (0)
-
 #if TRACE_MATRICES
 #define TRACE_MATRIX(m, desc) DUMP_MATRIX(m, desc)
 #define TRACELN(msg)          std::cerr << msg << std::endl;

--- a/test/test_endtoend.py
+++ b/test/test_endtoend.py
@@ -68,6 +68,8 @@ class EndToEndTests(unittest.TestCase):
                 MRPAST
                 + [
                     "process",
+                    "--out-dir",
+                    tmpdirname,
                 ]
                 + extra_args
                 + [


### PR DESCRIPTION
By default, use the slower (but probably more accurate) bootstrapping method for confidence intervals.

The GIM method is still available with `--gim`, but bootstrapping is the default.

Also improve:
1. The error messages when the numerical (GIM) methods fail, with hints for users.
2. There is a mechanism for computing J differently now, though with lots of caveats for its use. It is marked as EXPERIMENTAL right now (and maybe always).
3. Make the output consistent from "mrpast confidence" and add support to "mrpast show" for such output.
4. Update docs to reflect the change, and the preference for bootstrapped intervals.