### PR TITLE
Handle NaN log-likelihood values more thoroughly

### DIFF
--- a/mrpast/main.py
+++ b/mrpast/main.py
@@ -26,6 +26,7 @@ import glob
 import json
 import os
 import pandas as pd
+import random
 import re
 import subprocess
 import sys
@@ -1105,6 +1106,7 @@ def main():
 
         leave_out = parse_intlist(args.leave_out)
 
+        random.seed(args.seed)
         try:
             process_ARGs(
                 args.model,
@@ -1280,6 +1282,7 @@ def main():
                 )
                 exit(2)
             os.mkdir(out_dir)
+            random.seed(args.seed)
             with open(args.solved_result) as f:
                 base_input = ModelSolverInput.from_json(f.read())
             if args.replicates is not None:
@@ -1349,8 +1352,9 @@ def main():
                 file=sys.stderr,
             )
             exit(1)
-        result = subprocess.check_output(cmd + args.solved_results)
-        print(result)
+        result = subprocess.check_output(cmd + args.solved_results).decode("utf-8")
+        result = json.loads(result)
+        print(json.dumps(result, indent=2))
     else:
         parser.print_help()
         exit(1)

--- a/src/mrp_eval.cpp
+++ b/src/mrp_eval.cpp
@@ -460,17 +460,21 @@ void selectCommand(args::Subparser& parser) {
             const double logLikelihood = cost(paramVector.data());
             likelihoods.push_back(logLikelihood);
         } else {
+            user_exc_check(resultFile.size() > 4, "Invalid filename: " << resultFile);
             // Load the likelihood values from the CSV (take the 0'th parameter)
             // The number of likelihood values should match the # of coal matrices in the JSON
             // Compute all metrics and add to a list
             std::stringstream ssCsvFile;
             ssCsvFile << resultFile.substr(0, resultFile.size() - 4) << "bootstrap.csv";
             std::ifstream csvFile(ssCsvFile.str());
+            user_exc_check(csvFile.good(), "Cannot read bootstrap file " << ssCsvFile.str());
             likelihoods = loadNegLL(csvFile);
             // We have negative log-likelihoods, convert to log-likelihoods
             for (size_t i = 0; i < likelihoods.size(); i++) {
                 likelihoods[i] = -likelihoods[i];
             }
+            user_exc_check(likelihoods.size() == numSamples,
+                           "Bootstrap file " << ssCsvFile.str() << " has too few results: " << likelihoods.size());
         }
         RELEASE_ASSERT(likelihoods.size() == numSamples);
 

--- a/src/mrp_solver.cpp
+++ b/src/mrp_solver.cpp
@@ -53,6 +53,11 @@ int main(int argc, char** argv) {
         {'t', "timeout"});
     args::Flag randomInit(
         parser, "randomInit", "Ignore the initial values in the input file and randomize them", {'r', "random-init"});
+    args::ValueFlag<size_t> randomRestarts(
+        parser,
+        "randomRestart",
+        "If the init value results in negLL=NaN, restart with a different init value this many times (deterministic).",
+        {"random-restarts"});
     args::ValueFlag<size_t> selectMatrix(parser,
                                          "selectMatrix",
                                          "Select a specific coal matrix from the list of matrices in the input JSON.",
@@ -88,6 +93,7 @@ int main(int argc, char** argv) {
 
     std::vector<double> paramVector(cost.m_schema.totalParams());
     if (randomInit) {
+        setRandSeedToTime();
         cost.m_schema.randomParamVector(paramVector.data());
     } else {
         cost.m_schema.initParamVector(paramVector.data());
@@ -98,7 +104,30 @@ int main(int argc, char** argv) {
     std::cerr << std::endl;
 
     const double timeoutSec = timeout ? *timeout : DEFAULT_TIMEOUT_SECONDS;
-    const double minf = solve(cost, paramVector, MRP_OPT_ALG, true, timeoutSec);
+    const size_t maxRestarts = randomRestarts ? *randomRestarts : DEFAULT_RESTARTS;
+    double minf = std::numeric_limits<double>::quiet_NaN();
+    size_t restarts = 0;
+    do {
+        minf = solve(cost, paramVector, MRP_OPT_ALG, true, timeoutSec);
+        if (std::isnan(minf)) {
+            // For our first restart, initialize the seed to the integer sum of all parameters.
+            if (restarts == 0) {
+                uint64_t seed = 0;
+                for (const double v : paramVector) {
+                    seed += (uint64_t)(v * 1001001001); // Multiply by a big number so we don't just get 0 for int
+                }
+                setRandSeed(seed);
+            }
+            cost.m_schema.randomParamVector(paramVector.data());
+            restarts++;
+            std::cerr << "Restarting solver due to NaN (" << restarts << "/" << maxRestarts << ")" << std::endl;
+        }
+    } while (std::isnan(minf) && restarts <= maxRestarts);
+
+    // Don't let the solver silently return NaN to the Python code.
+    user_exc_check(!std::isnan(minf),
+                   "Likelihood is NaN after "
+                       << restarts << " restarts; your model may be problematic (try restricting the bounds more)");
 
     if (*outfile != std::string("-")) {
         std::ofstream outputData(*outfile);

--- a/src/objective.cpp
+++ b/src/objective.cpp
@@ -50,9 +50,14 @@ using Eigen::VectorXd;
 #define TRACELN(msg)
 #endif
 
+static uint64_t randSeed = 0;
+
+void setRandSeed(const uint64_t seed) { randSeed = seed; }
+
+void setRandSeedToTime() { randSeed = std::chrono::system_clock::now().time_since_epoch().count(); }
+
 double randDouble(const double lower, const double upper) {
-    static unsigned seed = std::chrono::system_clock::now().time_since_epoch().count();
-    static std::default_random_engine generator(seed);
+    static std::default_random_engine generator(randSeed);
     std::uniform_real_distribution<double> sampler(lower, upper);
     return sampler(generator);
 }

--- a/src/objective.h
+++ b/src/objective.h
@@ -43,6 +43,11 @@ static constexpr double EPOCH_TIME_RESCALE = 1e-6;
 // should always be noticeable enough to prevent these scenarios (hopefully).
 static constexpr double ADMIXTURE_PENALTY = 100000;
 
+// Number of times the solver will restart if it encounters NaN for a likelihood value. The
+// restart uses a new random initialization vector that is deterministic based on the original
+// initialization vector.
+static constexpr size_t DEFAULT_RESTARTS = 10;
+
 // How we should treat the observed data (coal matrices).
 enum ObservationMode {
     OBS_MODE_UNSPECIFIED = 0,
@@ -385,5 +390,11 @@ private:
     const bool m_maximization;
     ObservationMode m_mode;
 };
+
+// Set the random seed that is used for parameter initialization.
+void setRandSeed(uint64_t seed);
+// Set the random seed that is used for parameter initialization to the current time
+// (less deterministic randomness)
+void setRandSeedToTime();
 
 #endif /* MRP_SOLVER_OBJECTIVE_H */


### PR DESCRIPTION
For certain models, random initialization of the parameters can result in NaN for the log-likelihood. E.g., when the initialization chooses extreme values that do not match the coalescent counts. The result previously was just a negLL value of None in the solver output, and for bootstrapping it could result in not enough replicates being present in the bootstrap output (which was fine, unless you tried to use it for model selection).

This changeset:
1. Makes the solver explicitly throw an error if the final likelihood is NaN.
2. Adds in automatic retrying for NaN results (up to 10 retries), which reinitializes the starting position for the gradient descent. This reinitialization is random, but deterministic based on the original start position (init vector).
3. The output from model selection is now properly formatted.
4. The model selection presents a more helpful error message when the input files don't exist or do not contain enough replicates.
5. `mrpast process` and `mrpast select` both use the default or provided random seed, so that the results are now deterministic. You can change the seed via `--seed <your seed>`.