### PR TITLE
Update requirements.txt for doc build; switch themes

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -4,6 +4,6 @@ import sys
 sys.path.insert(0, os.path.abspath('../'))
 
 extensions = ["sphinx.ext.autodoc", "sphinx.ext.autosummary"]
-html_theme = "sphinx_rtd_theme"
+html_theme = "pydata_sphinx_theme"
 autosummary_generate = True
 project = "mrpast"

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,1 +1,9 @@
-sphinx-rtd-theme
+dataclasses_json
+msprime
+numpy
+orjson
+pandas
+pydata-sphinx-theme
+pyfaidx
+pyyaml
+tskit


### PR DESCRIPTION
Missing requirements for RTD were causing the API docs to not be generated properly.