### PR TITLE
Remove Python 3.8 from build script

### DIFF
--- a/package.sh
+++ b/package.sh
@@ -8,13 +8,10 @@ PKG=mrpast
 VER=0
 
 # Build the source distribution
-/opt/python/cp38-cp38/bin/pip install setuptools
-/opt/python/cp38-cp38/bin/python setup.py sdist
-
-echo "Building for Python 3.8"
-/opt/python/cp38-cp38/bin/python setup.py bdist_wheel
-echo "Building for Python 3.9"
 /opt/python/cp39-cp39/bin/pip install setuptools
+/opt/python/cp39-cp39/bin/python setup.py sdist
+
+echo "Building for Python 3.9"
 /opt/python/cp39-cp39/bin/python setup.py bdist_wheel
 echo "Building for Python 3.10"
 /opt/python/cp310-cp310/bin/pip install setuptools
@@ -30,7 +27,6 @@ echo "Building for Python 3.13"
 /opt/python/cp313-cp313/bin/python setup.py bdist_wheel
 
 cd /io/mrpast/dist
-auditwheel repair --plat manylinux_2_24_x86_64 ${PKG}-${VER}.*-cp38-cp38-linux_x86_64.whl
 auditwheel repair --plat manylinux_2_24_x86_64 ${PKG}-${VER}.*-cp39-cp39-linux_x86_64.whl
 auditwheel repair --plat manylinux_2_24_x86_64 ${PKG}-${VER}.*-cp310-cp310-linux_x86_64.whl
 auditwheel repair --plat manylinux_2_24_x86_64 ${PKG}-${VER}.*-cp311-cp311-linux_x86_64.whl


### PR DESCRIPTION
many-linux docker image no longer supports 3.8