### PR TITLE
Add "mrpast pops" command for attaching/view ARG populations

### DIFF
--- a/docs/overview/concepts.rst
+++ b/docs/overview/concepts.rst
@@ -117,8 +117,8 @@ model and the map that associates them. The population map JSON looks like:
 
   {
     "mapping": [
-      [ ... ],                       <-- list of individual indexes that are in the first population by model order
-      [ ... ],                       <-- list of individual indexes that are in the second population by model order
+      [ ... ],                       <-- list of individual indexes that are in the first population
+      [ ... ],                       <-- list of individual indexes that are in the second population
       ... 
     ],
     "names": [

--- a/docs/overview/concepts.rst
+++ b/docs/overview/concepts.rst
@@ -168,6 +168,13 @@ For both simulation and inference, *mrpast* uses `msprime.RateMap <https://tskit
 The only place where this is not true is for ``mrpast arginfer --tool relate``, which requires `Relate's input format for rates <https://myersgroup.github.io/relate/input_data.html>`_.
 If you have rate maps downloaded in HapMap-style, you can convert them to what *mrpast* needs via `make_rate_map.py <https://github.com/aprilweilab/mrpast/blob/main/scripts/make_rate_map.py>`_.
 
+For recombination maps, mrpast can take either a single file (with a .txt extension) or a file prefix. When
+using a single file, it will use the same map for all chromosomes being processed. When using a file prefix,
+the number of files matching that prefix must match the number of chromosomes. And the recombination maps
+are paired up according to lexicographic order: so it is expected that each file has the same prefix and
+then a suffix like chr1, chr2, etc., (whatever matches the ordered names of your ARGs for those chromosomes)
+prior to the file extension.
+
 Model/ARG Population Mismatches
 -------------------------------
 

--- a/docs/reference/commands.rst
+++ b/docs/reference/commands.rst
@@ -262,3 +262,33 @@ Typical usage is ``mrpast select ... > selection_results.json``, and then loadin
     options:
     -h, --help       show this help message and exit
     --bootstrap, -b  Emit the distribution of AIC values for all bootstrapped samples. Requires that you have previously run 'mrpast confidence --bootstrap' to produce a .csv for each of the solved_results.
+
+``mrpast pops``
+---------------
+
+Show the population information that is attached to an existing ARG(s):
+
+::
+
+    usage: mrpast pops show [-h] arg_prefix
+
+    positional arguments:
+    arg_prefix  The filename prefix for finding the input ARGs (.trees files)
+
+    options:
+    -h, --help  show this help message and exit
+
+Attach a `population map <../overview/concepts.html#population-maps>`_ to an existing ARG(s):
+
+::
+
+    usage: mrpast pops attach [-h] [--ploidy PLOIDY] arg_prefix out_prefix pop_map
+
+    positional arguments:
+    arg_prefix       The filename prefix for finding the input ARGs (.trees files)
+    out_prefix       The output prefix for writing the ARGs (now containing population info).
+    pop_map          The file containing the population map (*.popmap.json)
+
+    options:
+    -h, --help       show this help message and exit
+    --ploidy PLOIDY  The ploidy of individuals. Default: 2

--- a/docs/workflows/custom.rst
+++ b/docs/workflows/custom.rst
@@ -1,0 +1,87 @@
+
+Externally-created ARGs
+=======================
+
+This page walks you through an example using mrpast with `tskit ARGs <https://tskit.dev/learn/>`_ that
+were inferred outside of ``mrpast`` (e.g., without using ``mrpast arginfer``). 
+
+.. warning::
+
+  On the models we have tested, using ``mrpast`` with ``SINGER`` or ``Relate`` was not as accurate as ``tsinfer+tsdate``. It may be worth comparing multiple ARG inference methods on your model(s).
+
+``mrpast process`` is the command that takes your ARGs as input, and it requires the following:
+
+* One or more ``.trees`` files with the same prefix. The expectation is that the suffix encodes two pieces of information: (1) the chromosome number, and the (2) MC/MC sample number (if applicable). The chromosome numbering should follow the same ordering as any `Rate Maps <../overview/concepts.html#rate-maps>`_ that will be used.
+* Proper sample-to-population mapping in the ``.trees`` files.
+
+ARG filenames and sampling
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+``mrpast`` works best with as many local trees as possible, which means usually you should use an ARG for each of
+the autosomes of the population(s) you are studying. The primary ordering of the ARG filenames is expected to
+be based on the *chromosome number*. For example, for humans you might have ARG filenames that look like:
+
+::
+
+  myarg_1.trees
+  myarg_2.trees
+  ...
+  myarg_22.trees
+
+With such ARGs, you can do the following use-cases:
+
+1. Multiple chromosomes, single MC/MC replicate, no bootstrapping: ``mrpast process --bootstrap none <model> myarg_``. This will produce a coalescence matrix from all sampled trees, across all chromosomes. Subsequent model solving will produce a single point estimate.
+2. Multiple chromosomes, single MC/MC replicate, with bootstrapping (the default): ``mrpast process <model> myarg_``. This will produce ``100`` coalescence matrices from all sampled trees, across all chromosomes, by bootstrap sampling said trees. Subsequent model solving will produce a single point estimate, based on the average of the bootstrapped matrices. Future calls to ``mrpast confidence`` and ``mrpast select`` can use the bootstrapped matrices in more detail.
+
+You will see output messages like ``Using a single ARG sample with sampling method arg_samples`` and
+``Using a single ARG sample with sampling method bootstrap``, respectively, for the above use cases.
+
+See `bootstrapping <../overview/bootstrapping.html>`_ for more details on how bootstrapping works.
+
+If you have MC/MC samples from an ARG (e.g., branch length MC/MC samples from ``Relate`` or full ARG MC/MC samples from ``SINGER``)
+you can use those *instead of bootstrapping*. This has two effects: (a) the point estimates are derived from the coalescence
+matrix that is the average of the coalescence matrices for each MC/MC sample, and (b) downstream confidence intervals from ``mrpast confidence``
+will use the MC/MC samples instead of bootstrap samples as input for estimating parameter variance.
+
+.. warning::
+
+  In our limited testing, MC/MC samples from ``Relate`` and ``SINGER`` produced *less variation in mrpast results*
+  than tree-based bootstrapping did. That is, you are likely to get wider confidence intervals (and better coverage)
+  with bootstrapping.
+
+
+Extending our human example above, if we had 2 MC/MC samples per chromosome (i.e., 44 ARGs), the naming should look like:
+
+::
+
+  myarg_1.sample0.trees
+  myarg_1.sample1.trees
+  myarg_2.sample0.trees
+  myarg_2.sample1.trees
+  ...
+  myarg_22.sample0.trees
+  myarg_22.sample1.trees
+
+
+You can make use of these MC/MC samples via ``mrpast process --bootstrap none <model> myarg_``. You should
+see an output message like ``Using 2 ARG samples with sampling method arg_samples``. Theoretically, you can
+combine bootstrapping and MC/MC samples, but this is not well-tested and is somewhat complicated - it is
+recommended to use ``--bootstrap none`` if MC/MC samples are used. If you want bootstrapping with an MC/MC-based
+ARG tool, it is recommended to just use the last MC/MC sample for each chromosome, instead of all MC/MC samples.
+
+.. note::
+
+  The default regular expression for finding MC/MC samples assumes that everything before ``sample`` is the
+  chromosome ordering, and everything after is sample ordering (regex is ``sample([0-9]+)(_v[0-9]+)?.trees``).
+  Advanced users can change this regex with the ``--group-by`` option.
+
+
+Attaching and checking populations
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+You can attach population information to your ARGs in a few ways.
+
+1. You can write your own script(s). See `attach_populations_ts() <https://github.com/aprilweilab/mrpast/blob/main/mrpast/arginfer.py>`_ for an example of how to do this. The main requirements are that (a) every sample should be assigned to a population, and (b) the `population metadata <https://tskit.dev/tskit/docs/stable/python-api.html#tskit.Population.metadata>`_ should have a ``name`` field.
+2. You can create a mrpast-style ``.popmap.json`` file (see `here <../overview/concepts.html#population-maps>`_) and use the ``mrpast pops attach`` command.
+
+``mrpast pops view <args prefix>`` can be used to view the population information in a set of ARGs.

--- a/docs/workflows/index.rst
+++ b/docs/workflows/index.rst
@@ -5,6 +5,7 @@ Workflows
   :maxdepth: 2
 
   tsinfer workflows <tsinfer>
+  custom
   Examining results <results>
   Using real data <real_data>
   Very short examples <examples>

--- a/mrpast/main.py
+++ b/mrpast/main.py
@@ -57,14 +57,16 @@ from mrpast.simulate import (
     build_demography,
 )
 from mrpast.arginfer import (
-    infer_arg,
     ArgTool,
-    DEFAULT_SAMPLE_SUFFIX,
     DEFAULT_NUM_SAMPLES as DEFAULT_ARG_SAMPLES,
+    DEFAULT_SAMPLE_SUFFIX,
+    attach_populations_ts,
+    infer_arg,
 )
 from mrpast.model import (
-    UserModel,
     ModelSolverInput,
+    PopMap,
+    UserModel,
     print_model_warnings,
 )
 from mrpast.simprocess import (
@@ -116,6 +118,7 @@ CMD_CONFIDENCE = "confidence"
 CMD_POLARIZE = "polarize"
 CMD_SHOW = "show"
 CMD_SELECT = "select"
+CMD_POPS = "pops"
 
 
 class BootstrapOpt(Enum):
@@ -257,13 +260,11 @@ def get_popsummary_from_args(
                     )
         assert all(map(lambda pstr: len(pstr) > 0, pop2names))
         pop2count = [0 for _ in pop2names]
-        for tree in ts.trees():
-            for i in ts.samples():
-                pop_id = tree.population(i)
-                if pop_id not in leave_out_pops:
-                    pop_id = pop_idx_map.get(pop_id, pop_id)
-                    pop2count[pop_id] += 1
-            break
+        for i in ts.samples():
+            pop_id = ts.node(i).population
+            if pop_id not in leave_out_pops:
+                pop_id = pop_idx_map.get(pop_id, pop_id)
+                pop2count[pop_id] += 1
         if not result:
             result.extend([(n, c) for n, c in zip(pop2names, pop2count)])
         else:
@@ -1136,6 +1137,35 @@ def main():
         "for each of the solved_results.",
     )
 
+    pops_parser = subparsers.add_parser(
+        CMD_POPS, help="Attach or view population maps for ARGs."
+    )
+    pops_sub = pops_parser.add_subparsers(dest="pops_cmd")
+    pop_attach = pops_sub.add_parser(
+        "attach", help="Attach a population map to one or more ARGs."
+    )
+    pop_attach.add_argument(
+        "arg_prefix",
+        help="The filename prefix for finding the input ARGs (.trees files)",
+    )
+    pop_attach.add_argument(
+        "out_prefix",
+        help="The output prefix for writing the ARGs (now containing population info).",
+    )
+    pop_attach.add_argument(
+        "pop_map", help="The file containing the population map (*.popmap.json)"
+    )
+    pop_attach.add_argument(
+        "--ploidy", default=2, type=int, help="The ploidy of individuals. Default: 2"
+    )
+    pop_show = pops_sub.add_parser(
+        "show", help="Show population info from one or more ARGs."
+    )
+    pop_show.add_argument(
+        "arg_prefix",
+        help="The filename prefix for finding the input ARGs (.trees files)",
+    )
+
     args = parser.parse_args()
 
     if args.command == CMD_SIMULATE:
@@ -1438,6 +1468,46 @@ def main():
         result = subprocess.check_output(cmd + args.solved_results).decode("utf-8")
         result = json.loads(result)
         print(json.dumps(result, indent=2))
+    elif args.command == CMD_POPS:
+        input_args = list(glob.glob(args.arg_prefix + "*.trees"))
+        print(f"Found {len(input_args)} input ARGs.", file=sys.stderr)
+
+        if args.pops_cmd == "show":
+            for in_arg in input_args:
+                ts = tskit.load(in_arg)
+                pop2names = [None] * ts.num_populations
+                for pop in ts.populations():
+                    pop2names[pop.id] = pop.metadata.get("name")
+                pop2count = [0 for _ in pop2names]
+                for i in ts.samples():
+                    pop_id = ts.node(i).population
+                    pop2count[pop_id] += 1
+                print(
+                    f"{in_arg} has populations {pop2names} with sample counts {pop2count}"
+                )
+
+        elif args.pops_cmd == "attach":
+            with open(args.pop_map) as f:
+                pop_map = PopMap.from_json(f.read())
+
+            for in_arg in input_args:
+                assert in_arg.startswith(args.arg_prefix)
+                suffix = in_arg[len(args.arg_prefix) :]
+                out_arg = args.out_prefix + suffix
+                if os.path.exists(out_arg):
+                    raise UserInputError(
+                        f"Output file {out_arg} already exists; remove and try again."
+                    )
+                ts = tskit.load(in_arg)
+                with_pops = attach_populations_ts(ts, pop_map, args.ploidy)
+                with_pops.dump(out_arg)
+                print(
+                    f"Wrote {out_arg} with {len(pop_map.mapping)} populations, "
+                    f"{sum([len(p) for p in pop_map.mapping])} samples, ploidy={args.ploidy}",
+                    file=sys.stderr,
+                )
+        else:
+            assert False, f"Invalid command: {args.pops_cmd}"
     else:
         parser.print_help()
         exit(1)

--- a/mrpast/main.py
+++ b/mrpast/main.py
@@ -398,9 +398,14 @@ def get_coal_counts(
     deme_pair_index0 = model.get_pair_ordering()
     coal_matrices = []
     if number_of_groups > 1:
-        print(f"Using {number_of_groups} ARG sample with sampling method {description}")
+        print(
+            f"Using {number_of_groups} ARG samples with sampling method {description}",
+            file=sys.stderr,
+        )
         if bootstrap == BootstrapOpt.none:
+            sample_hashes = []
             for _, group_files in sorted(grouped_filenames.items(), key=lambda t: t[0]):
+                print(f"Sample is {group_files}", file=sys.stderr)
                 group_sampler = deepcopy(sampler)
                 sample_coal_matrices(
                     group_files,
@@ -413,11 +418,12 @@ def get_coal_counts(
                 )
                 assert len(group_sampler.coal_matrices) == 1
                 coal_matrices.append(group_sampler.coal_matrices[0])
+                sample_hashes.extend(group_sampler.sample_hashes())
         else:
             coal_files = []
             for group, grouped_files in grouped_filenames.items():
                 merged_file = f"{group}-avg-coal.txt"
-                print(f"Merging {grouped_files} -> {merged_file}")
+                print(f"Merging {grouped_files} -> {merged_file}", file=sys.stderr)
                 merge_coals(grouped_files, merged_file)
                 coal_files.append(merged_file)
             sample_coal_matrices(
@@ -430,6 +436,7 @@ def get_coal_counts(
                 pop_idx_map=pop_idx_map,
             )
             coal_matrices = list(sampler.coal_matrices)
+            sample_hashes = sampler.sample_hashes()
     else:
         print(f"Using a single ARG sample with sampling method {description}")
         coal_files = list(grouped_filenames.values())[0]
@@ -443,7 +450,8 @@ def get_coal_counts(
             pop_idx_map=pop_idx_map,
         )
         coal_matrices = list(sampler.coal_matrices)
-    return coal_matrices, description, sampler.sample_hashes()
+        sample_hashes = sampler.sample_hashes()
+    return coal_matrices, description, sample_hashes
 
 
 def generate_solver_input(

--- a/mrpast/simprocess.py
+++ b/mrpast/simprocess.py
@@ -65,7 +65,7 @@ def update_coalescence_map(
         pop_idx = tree.population(sample_id)
         if pop_idx < 0:
             raise UserInputError(
-                "tskit ARG does not have sample->population information; try 'mrpast pop-attach' or see https://mrpast.readthedocs.io/en/latest/workflows/custom.html"
+                "tskit ARG does not have sample->population information; try 'mrpast pops attach' or see https://mrpast.readthedocs.io/en/latest/workflows/custom.html"
             )
         return pop_idx
 

--- a/mrpast/simprocess.py
+++ b/mrpast/simprocess.py
@@ -62,7 +62,12 @@ def update_coalescence_map(
         rate_map = load_rate_map(recomb_map_file)
 
     def sample_pop(sample_id: int, tree: tskit.Tree) -> int:
-        return tree.population(sample_id)
+        pop_idx = tree.population(sample_id)
+        if pop_idx < 0:
+            raise UserInputError(
+                "tskit ARG does not have sample->population information; try 'mrpast pop-attach' or see https://mrpast.readthedocs.io/en/latest/workflows/custom.html"
+            )
+        return pop_idx
 
     # Recursively collect the vector [p_0, p_1, ..., p_k] where there are k populations in the
     # ARG, and p_i is the count of samples below the current node that are in population i.

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from setuptools import setup, Extension
 from setuptools.command.build_ext import build_ext
 
 PACKAGE_NAME = "mrpast"
-VERSION = "0.4"
+VERSION = "0.5"
 
 
 THIS_DIR = os.path.dirname(os.path.realpath(__file__))


### PR DESCRIPTION
* `mrpast pops` can be helpful when using externally-created ARGs, or debugging issues.
* Add documentation for externally-created ARGs, including warnings for pitfalls.
* Fix the tree hash generation for MC/MC sampling, and document the filename ordering for the MC/MC ARGs